### PR TITLE
#68 히스토리/보관함 UI 스타일 수정

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -82,7 +82,7 @@ export const keywordAPI = {
 export const historyAPI = {
   getHistoryList: (pageNum) => logined.get(`/history?page-num=${pageNum}`),
   deleteHistoryList: (historyList) => logined.patch(`history?${historyList}`),
-  readHistoryItem: (noticeId) => logined.put(`/history?notice-id=${noticeId}`),
+  readHistoryItem: (noticeId) => logined.put(`/history/${noticeId}`),
   moveToScrap: (idList) => logined.post(`/scrap`, idList),
   undoHistoryList: (idList) => logined.patch(`history/undo?${idList}`),
 };

--- a/src/components/History/History/History.Style.js
+++ b/src/components/History/History/History.Style.js
@@ -30,14 +30,12 @@ export const KeyWordAlert = styled.li`
   }
 `;
 export const KeyWordAlertList = styled.ol`
-  // width: calc(100vw * 0.6671875 + 40px);
-  
   height: calc(100vh - 337px);
   overflow-y: scroll;
   padding-right: 40px;
   @media screen and (max-width: ${tabletL}) {
     width: 100%;
-    height: calc(100vh-74px);
+    height: calc(100vh - 200px);
     margin: 0 0 0 5%;
   }
 `;
@@ -67,10 +65,6 @@ export const Sender = styled.div`
     width: 52px;
     margin: 0;
   }
-  // @media (min-width: ${(props)=>props.theme.deviceSizes.tabletL}) and (max-width: ${(props)=>props.theme.deviceSizes.NoteBook}){
-  //   margin-right: 50px;
-  
-  // }
 `;
 export const AlertInfo = styled.div`
   display: flex;
@@ -117,7 +111,6 @@ export const AlertDetail = styled.div`
 export const MailBrowse = styled.div`
   width: 47px;
   min-width: 47px;
-  // margin-left: 40px;
   margin-right: 24px;
   text-align: center;
   font-size: 11px;
@@ -177,10 +170,6 @@ export const PageWrapper = styled.div`
     width: 100vw;
     margin: 0 0 74px 0;
   }
-  // @media (min-width: ${(props)=>props.theme.deviceSizes.tabletL}) and (max-width: ${(props)=>props.theme.deviceSizes.NoteBook}){
-  //   width: 900px;
-  //   height: 400px;
-  // }
 `;
 export const Content = styled.div`
   position: relative;

--- a/src/components/History/History/History.Style.js
+++ b/src/components/History/History/History.Style.js
@@ -24,6 +24,7 @@ export const KeyWordAlert = styled.li`
   border-bottom: 1px solid ${lightgray};
   @media screen and (max-width: ${tabletL}) {
     position: relative;
+    width: 100%;
     justify-content: start;
     border: none;
   }
@@ -51,7 +52,7 @@ export const AlertBorderBox = styled.div`
       display: block;
       content: '';
       margin-left: 3%;
-      width: 87%;
+      width: 88%;
       border-bottom: 1px solid ${lightgray};
     }
   }
@@ -101,7 +102,7 @@ export const AlertContent = styled.div`
   width: 100%;
   @media screen and (max-width: ${tabletL}) {
     display: block;
-    max-width: 87%;
+    max-width: 90%;
     overflow: hidden;
     text-overflow: ellipsis;
   }

--- a/src/components/History/History/History.Style.js
+++ b/src/components/History/History/History.Style.js
@@ -17,7 +17,7 @@ export const SelectAll = styled.div`
 export const KeyWordAlert = styled.li`
   display: flex;
   position: relative;
-  width: calc(100vw * 0.6671875 + 40px);
+  width: ${props => props.isToggleOpen?'calc((100vw - 384px) * 0.6671875 + 40px);':'calc(100vw * 0.6671875 + 40px);'}
   max-width: 1281px;
   color: ${(props) => (props.isRead ? gray : darkgray)};
   padding: 15px 0 15px 0;
@@ -76,7 +76,7 @@ export const AlertInfo = styled.div`
   right: 0px;
 `
 export const AlertTitle = styled.a`
-  width: 70.17954722872756%;
+  width: ${props => props.isToggleOpen?'calc(80vw * 0.58528645833);':'calc(100vw * 0.468229166666);'}
   max-width: 899px;
   height: 18px;
   word-wrap : brek-word; 
@@ -93,6 +93,7 @@ export const AlertTitle = styled.a`
   @media screen and (max-width: ${tabletL}) {
     display: block;
     max-width: 90%;
+    width: 90%;
   }
 `;
 export const AlertContent = styled.div`

--- a/src/components/History/History/History.Style.js
+++ b/src/components/History/History/History.Style.js
@@ -16,8 +16,9 @@ export const SelectAll = styled.div`
 `;
 export const KeyWordAlert = styled.li`
   display: flex;
-  width: 1281px;
-  justify-content: space-between;
+  position: relative;
+  width: 100%;
+  max-width: 1281px;
   color: ${(props) => (props.isRead ? gray : darkgray)};
   padding: 15px 0 15px 0;
   border-bottom: 1px solid ${lightgray};
@@ -28,8 +29,10 @@ export const KeyWordAlert = styled.li`
   }
 `;
 export const KeyWordAlertList = styled.ol`
+  width: calc(100vw * 0.6671875 + 40px);
   height: calc(100vh - 337px);
   overflow-y: scroll;
+  padding-right: 40px;
   @media screen and (max-width: ${tabletL}) {
     width: 100%;
     height: calc(100vh-74px);
@@ -62,22 +65,31 @@ export const Sender = styled.div`
     width: 52px;
     margin: 0;
   }
-  @media (min-width: ${(props)=>props.theme.deviceSizes.tabletL}) and (max-width: ${(props)=>props.theme.deviceSizes.NoteBook}){
-    margin-right: 50px;
+  // @media (min-width: ${(props)=>props.theme.deviceSizes.tabletL}) and (max-width: ${(props)=>props.theme.deviceSizes.NoteBook}){
+  //   margin-right: 50px;
   
-  }
+  // }
 `;
+export const AlertInfo = styled.div`
+  display: flex;
+  position: absolute;
+  right: 0px;
+`
 export const AlertTitle = styled.a`
-  width: 899px;
+  width: 70.17954722872756%;
   max-width: 899px;
+  height: 18px;
+  word-wrap : brek-word; 
   max-height: 18px;
-  margin-right: 40px;
-  font-size: 12px;
-  color: ${(props) => (props.isRead ? gray : darkgray)};
-  cursor: pointer;
+  white-space: nowrap;
+  margin-right: 218px;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
+  font-size: 12px;
+
+  color: ${(props) => (props.isRead ? gray : darkgray)};
+  cursor: pointer;
+  
   @media screen and (max-width: ${tabletL}) {
     display: block;
     max-width: 90%;
@@ -85,6 +97,7 @@ export const AlertTitle = styled.a`
 `;
 export const AlertContent = styled.div`
   display: flex;
+  width: 100%;
   @media screen and (max-width: ${tabletL}) {
     display: block;
     max-width: 87%;
@@ -101,6 +114,8 @@ export const AlertDetail = styled.div`
 `;
 export const MailBrowse = styled.div`
   width: 47px;
+  min-width: 47px;
+  // margin-left: 40px;
   margin-right: 24px;
   text-align: center;
   font-size: 11px;
@@ -108,6 +123,7 @@ export const MailBrowse = styled.div`
 `;
 export const ReceiveDate = styled.div`
   width: 67px;
+  min-width: 67px;
   font-size: 11px;
   @media screen and (max-width: ${tabletL}) {
     position: relative;
@@ -159,10 +175,10 @@ export const PageWrapper = styled.div`
     width: 100vw;
     margin: 0 0 74px 0;
   }
-  @media (min-width: ${(props)=>props.theme.deviceSizes.tabletL}) and (max-width: ${(props)=>props.theme.deviceSizes.NoteBook}){
-    width: 900px;
-    height: 400px;
-  }
+  // @media (min-width: ${(props)=>props.theme.deviceSizes.tabletL}) and (max-width: ${(props)=>props.theme.deviceSizes.NoteBook}){
+  //   width: 900px;
+  //   height: 400px;
+  // }
 `;
 export const Content = styled.div`
   position: relative;

--- a/src/components/History/History/History.Style.js
+++ b/src/components/History/History/History.Style.js
@@ -1,11 +1,15 @@
 import styled from 'styled-components';
 import theme from '../../../theme';
+import HistoryCheckBox from './HisoryCheckBox';
 const { white, black, darkgray, lightgray, silver, gray, yellow } = theme.colors;
 const tabletL = theme.deviceSizes.tabletL;
 const mibileS = theme.deviceSizes.mobileS;
 
+
 export const SelectAll = styled.div`
-  margin: 0 25px 6px 0;
+  margin: 0 40px 6px 0;
+  display: flex;
+  align-items: center;
   @media screen and (max-width: ${tabletL}) {
     margin: 0 0 5px 0;
   }

--- a/src/components/History/History/History.Style.js
+++ b/src/components/History/History/History.Style.js
@@ -17,7 +17,7 @@ export const SelectAll = styled.div`
 export const KeyWordAlert = styled.li`
   display: flex;
   position: relative;
-  width: 100%;
+  width: calc(100vw * 0.6671875 + 40px);
   max-width: 1281px;
   color: ${(props) => (props.isRead ? gray : darkgray)};
   padding: 15px 0 15px 0;
@@ -29,7 +29,8 @@ export const KeyWordAlert = styled.li`
   }
 `;
 export const KeyWordAlertList = styled.ol`
-  width: calc(100vw * 0.6671875 + 40px);
+  // width: calc(100vw * 0.6671875 + 40px);
+  
   height: calc(100vh - 337px);
   overflow-y: scroll;
   padding-right: 40px;
@@ -82,7 +83,7 @@ export const AlertTitle = styled.a`
   word-wrap : brek-word; 
   max-height: 18px;
   white-space: nowrap;
-  margin-right: 218px;
+  margin-right: 178px;
   overflow: hidden;
   text-overflow: ellipsis;
   font-size: 12px;

--- a/src/components/History/History/History.Style.js
+++ b/src/components/History/History/History.Style.js
@@ -78,7 +78,6 @@ export const AlertInfo = styled.div`
   right: 0px;
 `
 export const AlertTitle = styled.a`
-  width: ${props => props.isToggleOpen?'calc((100vw - 354px) * 0.5740740740740741);':'(100vw - 144px) * 0.533214709371293);'}
   max-width: 899px;
   height: 18px;
   word-wrap : brek-word; 

--- a/src/components/History/History/History.Style.js
+++ b/src/components/History/History/History.Style.js
@@ -24,10 +24,10 @@ export const KeyWordAlert = styled.li`
   border-bottom: 1px solid ${lightgray};
   @media screen and (max-width: ${tabletL}) {
     position: relative;
-    width: 100%;
-    justify-content: start;
+    width: 90vw;
+    margin: 0 auto;
     border: none;
-  }
+    
 `;
 export const KeyWordAlertList = styled.ol`
   height: calc(100vh - 337px);
@@ -36,7 +36,11 @@ export const KeyWordAlertList = styled.ol`
   @media screen and (max-width: ${tabletL}) {
     width: 100%;
     height: calc(100vh - 200px);
-    margin: 0 0 0 5%;
+    padding: 0px;
+    &::-webkit-scrollbar { 
+      display: none;
+      width: 0
+  }
   }
 `;
 export const CheckBox = styled.div`
@@ -49,8 +53,8 @@ export const AlertBorderBox = styled.div`
     &:after {
       display: block;
       content: '';
-      margin-left: 3%;
-      width: 88%;
+      width: 85%;
+      margin-left: 9%; 
       border-bottom: 1px solid ${lightgray};
     }
   }
@@ -96,7 +100,7 @@ export const AlertContent = styled.div`
   width: 100%;
   @media screen and (max-width: ${tabletL}) {
     display: block;
-    max-width: 90%;
+    max-width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
   }
@@ -122,7 +126,6 @@ export const ReceiveDate = styled.div`
   font-size: 11px;
   @media screen and (max-width: ${tabletL}) {
     position: relative;
-    right: 2%;
   }
 `;
 export const MenuList = styled.div`
@@ -168,6 +171,7 @@ export const PageWrapper = styled.div`
   font-size: 12px;
   @media screen and (max-width: ${tabletL}) {
     width: 100vw;
+    min-width: ${theme.deviceSizes.mobileS};
     margin: 0 0 74px 0;
   }
 `;
@@ -176,8 +180,8 @@ export const Content = styled.div`
   margin: 0 0 0 13px;
   @media screen and (max-width: ${tabletL}) {
     width: 100%;
-    margin: 0 auto;
     top: 0;
+    margin: 0;
   }
 `;
 

--- a/src/components/History/History/History.Style.js
+++ b/src/components/History/History/History.Style.js
@@ -36,7 +36,10 @@ export const KeyWordAlertList = styled.ol`
     margin: 0 0 0 5%;
   }
 `;
-
+export const CheckBox = styled.div`
+  display: flex;
+  align-items: center;
+`;
 export const AlertBorderBox = styled.div`
   @media screen and (max-width: ${tabletL}) {
     width: 100%;

--- a/src/components/History/History/History.Style.js
+++ b/src/components/History/History/History.Style.js
@@ -17,7 +17,7 @@ export const SelectAll = styled.div`
 export const KeyWordAlert = styled.li`
   display: flex;
   position: relative;
-  width: ${props => props.isToggleOpen?'calc((100vw - 384px) * 0.6671875 + 40px);':'calc(100vw * 0.6671875 + 40px);'}
+  width: ${props => props.isToggleOpen?'calc((100vw - 354px) * 0.818007662835249);':'calc((100vw - 144px) * 0.7597864768683274 + 40px);'}
   max-width: 1281px;
   color: ${(props) => (props.isRead ? gray : darkgray)};
   padding: 15px 0 15px 0;
@@ -32,15 +32,17 @@ export const KeyWordAlert = styled.li`
 export const KeyWordAlertList = styled.ol`
   height: calc(100vh - 337px);
   overflow-y: scroll;
-  padding-right: 40px;
+  &::-webkit-scrollbar { 
+    display: none;
+    width: 0px;
+  }
   @media screen and (max-width: ${tabletL}) {
     width: 100%;
     height: calc(100vh - 200px);
-    padding: 0px;
     &::-webkit-scrollbar { 
       display: none;
-      width: 0
-  }
+      width: 0px;
+    }
   }
 `;
 export const CheckBox = styled.div`
@@ -76,13 +78,13 @@ export const AlertInfo = styled.div`
   right: 0px;
 `
 export const AlertTitle = styled.a`
-  width: ${props => props.isToggleOpen?'calc(80vw * 0.58528645833);':'calc(100vw * 0.468229166666);'}
+  width: ${props => props.isToggleOpen?'calc((100vw - 354px) * 0.5740740740740741);':'(100vw - 144px) * 0.533214709371293);'}
   max-width: 899px;
   height: 18px;
   word-wrap : brek-word; 
   max-height: 18px;
-  white-space: nowrap;
   margin-right: 178px;
+  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   font-size: 12px;

--- a/src/components/History/History/History.Style.js
+++ b/src/components/History/History/History.Style.js
@@ -12,6 +12,7 @@ export const SelectAll = styled.div`
 `;
 export const KeyWordAlert = styled.li`
   display: flex;
+  width: 1294px;
   justify-content: space-between;
   color: ${(props) => (props.isRead ? gray : darkgray)};
   padding: 15px 0 15px 0;
@@ -146,7 +147,6 @@ export const MenuName = styled.div``;
 
 export const PageWrapper = styled.div`
   display: block;
-  width: 1314px;
   font-size: 12px;
   @media screen and (max-width: ${tabletL}) {
     width: 100vw;

--- a/src/components/History/History/History.Style.js
+++ b/src/components/History/History/History.Style.js
@@ -12,7 +12,7 @@ export const SelectAll = styled.div`
 `;
 export const KeyWordAlert = styled.li`
   display: flex;
-  width: 1294px;
+  width: 1281px;
   justify-content: space-between;
   color: ${(props) => (props.isRead ? gray : darkgray)};
   padding: 15px 0 15px 0;
@@ -159,6 +159,7 @@ export const PageWrapper = styled.div`
 `;
 export const Content = styled.div`
   position: relative;
+  margin: 0 0 0 13px;
   @media screen and (max-width: ${tabletL}) {
     width: 100%;
     margin: 0 auto;

--- a/src/components/History/History/HistoryContent.js
+++ b/src/components/History/History/HistoryContent.js
@@ -217,15 +217,17 @@ const HistoryContent = () => {
       {!isMobile && <PopUp isOpen={isPopOpen} closePopUp={closePopUp} />}
         <S.Content isOpen={isPopOpen}>
           <S.MenuList>
+          <S.CheckBox>
           <HistoryCheckBox
                 onClick={(e) => selectAllMail(e)}
                 checked={checkedList.length <= 0 || checkedList.length !== showList.length ? false : true}
                 readOnly
               />
             <S.SelectAll>
-              
               전체선택
             </S.SelectAll>
+          </S.CheckBox>
+         
             <S.MenuWrapper onClick={(e) => e.stopPropagation()}>
               {!isMobile && (
                 <>

--- a/src/components/History/History/HistoryContent.js
+++ b/src/components/History/History/HistoryContent.js
@@ -217,12 +217,13 @@ const HistoryContent = () => {
       {!isMobile && <PopUp isOpen={isPopOpen} closePopUp={closePopUp} />}
         <S.Content isOpen={isPopOpen}>
           <S.MenuList>
-            <S.SelectAll>
-              <HistoryCheckBox
+          <HistoryCheckBox
                 onClick={(e) => selectAllMail(e)}
                 checked={checkedList.length <= 0 || checkedList.length !== showList.length ? false : true}
                 readOnly
               />
+            <S.SelectAll>
+              
               전체선택
             </S.SelectAll>
             <S.MenuWrapper onClick={(e) => e.stopPropagation()}>

--- a/src/components/History/History/HistoryContent.js
+++ b/src/components/History/History/HistoryContent.js
@@ -26,7 +26,7 @@ export const formatingDate = (date) => {
   const minute = newDate.getMinutes() < 10 ? '0' + newDate.getMinutes() : newDate.getMinutes();
   return `${month + '/' + day} - ${(hour === 0 ? '00' : hour) + ':' + (minute===0?'00':minute)}`;
 };
-const HistoryContent = () => {
+const HistoryContent = ({isToggleOpen}) => {
   const { historyList, deleteHistoryResponse, readHistoryItemResponse, moveToScrapResponse, undoHistoryListResponse } =
     useSelector((state) => state.history);
   const userInfo = useSelector((state) => state.auth);
@@ -272,7 +272,7 @@ const HistoryContent = () => {
           <S.KeyWordAlertList>
             {showList?.map((mail, id) =>
               showList[showList.length - 1].id === mail.id ? (
-                <S.KeyWordAlert isRead={mail.isRead} key={mail.id} ref={refAlert}>
+                <S.KeyWordAlert isRead={mail.isRead} key={mail.id} ref={refAlert} isToggleOpen={isToggleOpen}>
                   <HistoryCheckBox
                     onClick={(e) => selectMail(e, mail.id)}
                     checked={checkedList.includes(mail.id) ? true : false}
@@ -283,20 +283,20 @@ const HistoryContent = () => {
                       <S.Sender>{SITE_LIST[SITE_LIST.findIndex((site) => site.id === mail.site)].title}</S.Sender>
                       {isMobile && <S.ReceiveDate>{formatingDate(mail.createdAt)}</S.ReceiveDate>}
                     </S.AlertDetail>
-                    <S.AlertTitle href={mail.url} isRead={mail.isRead} onClick={(e) => clickMail(mail.id)}>
+                    <S.AlertTitle href={mail.url} isRead={mail.isRead} onClick={(e) => clickMail(mail.id)} isToggleOpen={isToggleOpen}>
                       {mail.title}
                     </S.AlertTitle>
                   </S.AlertContent>
                   {!isMobile && (
-                    <>
-                      <S.MailBrowse>{mail.isRead ? '읽음' : '읽지않음'}</S.MailBrowse>
-                      <S.ReceiveDate>{formatingDate(mail.createdAt)}</S.ReceiveDate>
-                    </>
-                  )}
+                      <S.AlertInfo>
+                        <S.MailBrowse>{mail.isRead ? '읽음' : '읽지않음'}</S.MailBrowse>
+                        <S.ReceiveDate>{formatingDate(mail.createdAt)}</S.ReceiveDate>
+                      </S.AlertInfo>
+                    )}
                 </S.KeyWordAlert>
               ) : (
                 <>
-                  <S.KeyWordAlert isRead={mail.isRead} key={mail.id}>
+                  <S.KeyWordAlert isRead={mail.isRead} key={mail.id} isToggleOpen={isToggleOpen}>
                     <HistoryCheckBox
                       onClick={(e) => selectMail(e, mail.id)}
                       checked={checkedList.includes(mail.id) ? true : false}
@@ -307,7 +307,7 @@ const HistoryContent = () => {
                         <S.Sender>{SITE_LIST[SITE_LIST.findIndex((site) => site.id === mail.site)].title}</S.Sender>
                         {isMobile && <S.ReceiveDate>{formatingDate(mail.createdAt)}</S.ReceiveDate>}
                       </S.AlertDetail>
-                      <S.AlertTitle href={mail.url} isRead={mail.isRead} onClick={(e) => clickMail(mail.id)}>
+                      <S.AlertTitle href={mail.url} isRead={mail.isRead} onClick={(e) => clickMail(mail.id)} isToggleOpen={isToggleOpen}>
                         {mail.title}
                       </S.AlertTitle>
                     </S.AlertContent>

--- a/src/components/History/History/HistoryContent.js
+++ b/src/components/History/History/HistoryContent.js
@@ -312,10 +312,10 @@ const HistoryContent = () => {
                       </S.AlertTitle>
                     </S.AlertContent>
                     {!isMobile && (
-                      <>
+                      <S.AlertInfo>
                         <S.MailBrowse>{mail.isRead ? '읽음' : '읽지않음'}</S.MailBrowse>
                         <S.ReceiveDate>{formatingDate(mail.createdAt)}</S.ReceiveDate>
-                      </>
+                      </S.AlertInfo>
                     )}
                   </S.KeyWordAlert>
                   {isMobile && <S.AlertBorderBox />}

--- a/src/components/History/History/HistoryHeader.js
+++ b/src/components/History/History/HistoryHeader.js
@@ -8,7 +8,7 @@ const {white, black, darkgray, lightgray, silver, gray, yellow} = theme.colors;
 
 const Header = styled.div`
   display: flex;
-  width: 1294px;
+  max-width: 1294px;
   border-bottom: 1px solid #eee;
   @media screen and (max-width: ${theme.deviceSizes.tabletL}) {
     width: 90%;
@@ -17,9 +17,9 @@ const Header = styled.div`
     align-items: center;
     padding: 0;
   }
-  @media (min-width: ${(props)=>props.theme.deviceSizes.tabletL}) and (max-width: ${(props)=>props.theme.deviceSizes.NoteBook}){
-    width: 900px;
-  }
+  // @media (min-width: ${(props)=>props.theme.deviceSizes.tabletL}) and (max-width: ${(props)=>props.theme.deviceSizes.NoteBook}){
+  //   width: 900px;
+  // }
 `;
 const FocusLine = styled.div`
   width: 32px;

--- a/src/components/History/History/HistoryHeader.js
+++ b/src/components/History/History/HistoryHeader.js
@@ -8,6 +8,7 @@ const {white, black, darkgray, lightgray, silver, gray, yellow} = theme.colors;
 
 const Header = styled.div`
   display: flex;
+  width: calc(100vw * 0.673958333 + 40px);
   max-width: 1294px;
   border-bottom: 1px solid #eee;
   @media screen and (max-width: ${theme.deviceSizes.tabletL}) {
@@ -17,21 +18,6 @@ const Header = styled.div`
     align-items: center;
     padding: 0;
   }
-  // @media (min-width: ${(props)=>props.theme.deviceSizes.tabletL}) and (max-width: ${(props)=>props.theme.deviceSizes.NoteBook}){
-  //   width: 900px;
-  // }
-`;
-const FocusLine = styled.div`
-  width: 32px;
-  height: 2px;
-  background-color: ${darkgray};
-  margin: ${(props) => {
-    if (props.location.pathname === '/history') {
-      return '0 0 0 40px';
-    } else if (props.location.pathname === '/history/scrap') {
-      return '0 0 0 190px';
-    }
-  }};
 `;
 const HistoryHeaderTab = styled(NavLink)`
   font-size: 18px;

--- a/src/components/History/History/HistoryHeader.js
+++ b/src/components/History/History/HistoryHeader.js
@@ -8,8 +8,7 @@ const {white, black, darkgray, lightgray, silver, gray, yellow} = theme.colors;
 
 const Header = styled.div`
   display: flex;
-  width: 1314px;
-  // padding-bottom: 31px;
+  width: 1294px;
   border-bottom: 1px solid #eee;
   @media screen and (max-width: ${theme.deviceSizes.tabletL}) {
     width: 90%;

--- a/src/components/History/History/HistoryHeader.js
+++ b/src/components/History/History/HistoryHeader.js
@@ -8,7 +8,8 @@ const {white, black, darkgray, lightgray, silver, gray, yellow} = theme.colors;
 
 const Header = styled.div`
   display: flex;
-  width: ${props => props.isOpen?'calc((100vw - 384px) * 0.673958333 + 40px)':'calc(100vw * 0.673958333 + 40px)'};
+  // width: ${props => props.isOpen?'calc((100vw - 384px) * 0.673958333 + 40px)':'calc(100vw * 0.673958333 + 40px)'};
+  width: ${props => props.isToggleOpen?'calc((100vw - 354px + 14px) * 0.818007662835249);':'calc((100vw - 144px) * 0.7597864768683274 + 40px + 14px);'}
   max-width: 1294px;
   border-bottom: 1px solid #eee;
   @media screen and (max-width: ${theme.deviceSizes.tabletL}) {
@@ -51,7 +52,7 @@ const HistoryHeader = ({ location, isToggleOpen }) => {
   const totlaAlertHistory = isMobile ? '전체알림' : '전체 알림 내역';
   return (
     <>
-      <Header isOpen={isToggleOpen}>
+      <Header isToggleOpen={isToggleOpen}>
         <>
           <HistoryHeaderTab to="/history" inlink={location.pathname === '/history' ? 1 : 0}>
             {totlaAlertHistory}

--- a/src/components/History/History/HistoryHeader.js
+++ b/src/components/History/History/HistoryHeader.js
@@ -8,7 +8,7 @@ const {white, black, darkgray, lightgray, silver, gray, yellow} = theme.colors;
 
 const Header = styled.div`
   display: flex;
-  width: calc(100vw * 0.673958333 + 40px);
+  width: ${props => props.isOpen?'calc((100vw - 384px) * 0.673958333 + 40px)':'calc(100vw * 0.673958333 + 40px)'};
   max-width: 1294px;
   border-bottom: 1px solid #eee;
   @media screen and (max-width: ${theme.deviceSizes.tabletL}) {
@@ -46,12 +46,12 @@ const HistoryHeaderTab = styled(NavLink)`
     }
   }
 `;
-const HistoryHeader = ({ location }) => {
+const HistoryHeader = ({ location, isToggleOpen }) => {
   const isMobile = useMediaQuery({ query: `(max-width:${theme.deviceSizes.tabletL}` });
   const totlaAlertHistory = isMobile ? '전체알림' : '전체 알림 내역';
   return (
     <>
-      <Header>
+      <Header isOpen={isToggleOpen}>
         <>
           <HistoryHeaderTab to="/history" inlink={location.pathname === '/history' ? 1 : 0}>
             {totlaAlertHistory}

--- a/src/components/History/History/HistoryPopup.js
+++ b/src/components/History/History/HistoryPopup.js
@@ -5,9 +5,9 @@ const {white} = theme.colors;
 
 const PopUpWindow = styled.div`
   display: ${(props) => (props.isOpen ? 'block' : 'none')};
-  position: fixed;
-  top: 20px;
-  left: 625px;
+  position: absolute;
+  top: 40px;
+  left: 42%;
   width: 265px;
   height: 110px;
   padding: 37px 0 0 30px;

--- a/src/components/History/History/MobileMenuModal.js
+++ b/src/components/History/History/MobileMenuModal.js
@@ -8,9 +8,9 @@ const Modal = styled.div`
   z-index: 99;
   flex-direction: column;
   justify-content: space-between;
-  position: fixed;
-  top: 17%;
-  right: 5%;
+  position: absolute;
+  top: 36px;
+  right: -8px;
   width: 98px;
   height: 44px;
   padding: 8px;

--- a/src/components/History/History/MobilePopUpModal.js
+++ b/src/components/History/History/MobilePopUpModal.js
@@ -6,7 +6,7 @@ const {white, black, darkgray, lightgray, silver, gray, yellow} = theme.colors;
 
 const Modal = styled.div`
   position: fixed;
-  top: 75%;
+  top: calc(100vh - 200px);
   left: 5%;
   width: 90%;
   height: 45px;

--- a/src/components/History/Scrap/MobileScrapAlert.Style.js
+++ b/src/components/History/Scrap/MobileScrapAlert.Style.js
@@ -18,7 +18,7 @@ export const Swiper =styled.div`
 `
 export const Alert = styled.div`
     width: 100%;
-    margin: 0 5% 0 5%;
+    margin: 0 5% 0 4.6%;
 `
 export const AlertWrapper = styled.li`
     @media screen and (max-width: ${tabletL}){

--- a/src/components/History/Scrap/MobileScrapAlert.Style.js
+++ b/src/components/History/Scrap/MobileScrapAlert.Style.js
@@ -5,7 +5,7 @@ const {white, black, darkgray, lightgray, silver, gray, yellow} = theme.colors;
 
 export const SwipeWrapper = styled.div`
     position: relative;
-    width: 95%;
+    width: 100vw;
     overflow: hidden;
     display: flex;
 `
@@ -13,16 +13,16 @@ export const Swiper =styled.div`
     display: flex;
     position: relative;
     left: 0;
-    width: 100%;
+    width: calc(90vw + 196px);
     transition: 0.3s ease;
 `
 export const Alert = styled.div`
-    min-width: 100%;
-    margin: 0 0 0 5%;
+    width: 100%;
+    margin: 0 5% 0 5%;
 `
 export const AlertWrapper = styled.li`
     @media screen and (max-width: ${tabletL}){
-        width: 99%;
+        width: 90vw;
         display: flex;
         justify-content: start;
         margin-top: 16px;
@@ -34,7 +34,7 @@ export const AlertWrapper = styled.li`
 export const AlertContent = styled.div`
     @media screen and (max-width: ${tabletL}) {
         display: block;
-        width: 85%;
+        width: 100%;
         overflow: hidden;
         text-overflow: ellipsis;
     }
@@ -42,7 +42,6 @@ export const AlertContent = styled.div`
 
 export const AlertDetail = styled.div`
     @media screen and (max-width: ${tabletL}) {
-    width: 96%;
     display: flex;
     justify-content: space-between;
     margin-bottom: 8px;
@@ -72,7 +71,7 @@ export const AlertBorderLine = styled.div`
     &:after{
         display: block;
         content:"";
-        width: 87%;
+        width: 100%;
         border-bottom: 1px solid ${lightgray};
         margin-left: 3%;
     }
@@ -112,8 +111,6 @@ export const Memo = styled.div`
 export const MemoFixBlock = styled.div`
   width: 88px;
   min-width: 88px;
-  // height: 119px;
-  // min-height: 119px;
   background: ${yellow};
   color: ${white};
   display: flex;
@@ -124,7 +121,6 @@ export const MemoFixBlock = styled.div`
 export const MemoWriteBlock = styled.div`
     width: 88px;
     min-width: 88px;
-    // heigth: 119px;
     background: ${darkgray};
     color: ${white};
     display: flex;
@@ -137,6 +133,7 @@ export const MenuBlock = styled.div`
   width: 176px;
   display:flex;
   border: 1px solid white;
+  margin: 0 0 0 2%;
 `
 
 export const Icon = styled.img`

--- a/src/components/History/Scrap/MobileScrapAlert.Style.js
+++ b/src/components/History/Scrap/MobileScrapAlert.Style.js
@@ -142,23 +142,26 @@ export const Icon = styled.img`
   margin-bottom: 11px;
 `
 export const MemoOption = styled.div`
-  width: 100%;
     display: flex;
+    position: relative;
     justify-content: space-between;
     color: ${gray};
-    margin: 11px 0 0 0;
+    margin: 22px 0 0 0;
 `
 export const LetterCounter = styled.div`
   font-size: 12px;
 `
 export const WriteBlockWrapper = styled.div`
-    width: 88%;
+    width: 100%;
     height: 74px;
     background: ${lightgray};
     padding: 8px;
     margin-top: 8px;
+    margin-left: 4px;
 `
 export const SaveBtn = styled.div`
   font-size: 11px;
   cursor: pointer;
+  position: absolute;
+  right: 22px;
 `

--- a/src/components/History/Scrap/MobileScrapAlert.Style.js
+++ b/src/components/History/Scrap/MobileScrapAlert.Style.js
@@ -6,6 +6,7 @@ const {white, black, darkgray, lightgray, silver, gray, yellow} = theme.colors;
 export const SwipeWrapper = styled.div`
     position: relative;
     width: 100vw;
+    min-width: ${theme.deviceSizes.mobileS};
     overflow: hidden;
     display: flex;
 `
@@ -71,9 +72,9 @@ export const AlertBorderLine = styled.div`
     &:after{
         display: block;
         content:"";
-        width: 100%;
+        width: 85%;
+      margin-left: 9%; 
         border-bottom: 1px solid ${lightgray};
-        margin-left: 3%;
     }
   }
 `
@@ -133,7 +134,6 @@ export const MenuBlock = styled.div`
   width: 176px;
   display:flex;
   border: 1px solid white;
-  // margin: 0 0 0 2%;
 `
 
 export const Icon = styled.img`

--- a/src/components/History/Scrap/MobileScrapAlert.Style.js
+++ b/src/components/History/Scrap/MobileScrapAlert.Style.js
@@ -13,18 +13,18 @@ export const Swiper =styled.div`
     display: flex;
     position: relative;
     left: 0;
-    width: calc(90vw + 196px);
+    width: calc(100vw + 196px);
     transition: 0.3s ease;
 `
 export const Alert = styled.div`
-    width: 100%;
-    margin: 0 5% 0 4.6%;
+    width: 100vw;
 `
 export const AlertWrapper = styled.li`
     @media screen and (max-width: ${tabletL}){
-        width: 90vw;
+        width: 90%;
         display: flex;
         justify-content: start;
+        margin: 0 auto;
         margin-top: 16px;
         margin-bottom: ${props=>props.state==='WRITE'?'9px':'15px'};
     }
@@ -133,7 +133,7 @@ export const MenuBlock = styled.div`
   width: 176px;
   display:flex;
   border: 1px solid white;
-  margin: 0 0 0 2%;
+  // margin: 0 0 0 2%;
 `
 
 export const Icon = styled.img`

--- a/src/components/History/Scrap/MobileScrapAlert.js
+++ b/src/components/History/Scrap/MobileScrapAlert.js
@@ -53,7 +53,7 @@ const MobileScrapAlert = ({mail, selectMail, list, memo, writeId, setCurr}) => {
     const TouchMove = (e) => {
         if(xCord - e.changedTouches[0].clientX > 100){
             console.log(swiperRef.current.style.width)
-            swiperRef.current.style.left = '-196px';
+            swiperRef.current.style.left = '-176px';
         }else if(xCord - e.changedTouches[0].clientX < -100){
             swiperRef.current.style.left = '0';
         }

--- a/src/components/History/Scrap/MobileScrapAlert.js
+++ b/src/components/History/Scrap/MobileScrapAlert.js
@@ -53,7 +53,7 @@ const MobileScrapAlert = ({mail, selectMail, list, memo, writeId, setCurr}) => {
     const TouchMove = (e) => {
         if(xCord - e.changedTouches[0].clientX > 100){
             console.log(swiperRef.current.style.width)
-            swiperRef.current.style.left = '-176px';
+            swiperRef.current.style.left = '-186px';
         }else if(xCord - e.changedTouches[0].clientX < -100){
             swiperRef.current.style.left = '0';
         }

--- a/src/components/History/Scrap/MobileScrapAlert.js
+++ b/src/components/History/Scrap/MobileScrapAlert.js
@@ -52,7 +52,8 @@ const MobileScrapAlert = ({mail, selectMail, list, memo, writeId, setCurr}) => {
 
     const TouchMove = (e) => {
         if(xCord - e.changedTouches[0].clientX > 100){
-            swiperRef.current.style.left = '-194px';
+            console.log(swiperRef.current.style.width)
+            swiperRef.current.style.left = '-196px';
         }else if(xCord - e.changedTouches[0].clientX < -100){
             swiperRef.current.style.left = '0';
         }

--- a/src/components/History/Scrap/MobileScrapAlert.js
+++ b/src/components/History/Scrap/MobileScrapAlert.js
@@ -114,7 +114,7 @@ const MobileScrapAlert = ({mail, selectMail, list, memo, writeId, setCurr}) => {
                     />
                     <M.AlertContent>
                         <M.AlertDetail>
-                            <M.Sender>{MENU_ITEM[MENU_ITEM.findIndex((site) => site.id === mail.site)].title}</M.Sender>
+                            <M.Sender>{SITE_LIST[SITE_LIST.findIndex((site) => site.id === mail.site)].title}</M.Sender>
                             <M.ReceiveDate>{formatingDate(mail.created_at)}</M.ReceiveDate>
                         </M.AlertDetail>
                         <M.AlertTitle>{mail.title}</M.AlertTitle>

--- a/src/components/History/Scrap/Scrap.Style.js
+++ b/src/components/History/Scrap/Scrap.Style.js
@@ -113,6 +113,7 @@ export const AlertProp = styled.div`
 export const StorageAlert = styled.li`
   display: flex;
   width: 1279px;
+  justify-content: space-between;
   color: ${darkgray};
   padding: 0 0 15px 0;
   margin: 15px 0 0 0;
@@ -129,7 +130,7 @@ export const MemoAlertWrapper = styled.div`
 `;
 export const AlertContent = styled.div`
   display: flex;
-
+  justify-content: space-between;
 `;
 export const AlertTitle = styled.a`
   width: 884px;

--- a/src/components/History/Scrap/Scrap.Style.js
+++ b/src/components/History/Scrap/Scrap.Style.js
@@ -11,7 +11,7 @@ export const MemoBlock = styled.div`
   font-size: 12px;
 `;
 export const WriteBlock = styled.textarea`
-  width: calc(100vw * 0.6671875 - 165px);
+  width: 100%;
   max-width: 1077px;
   height: 70px;
   border: none;
@@ -41,7 +41,7 @@ export const CheckBox = styled.div`
 export const MenuList = styled.div`
   display: flex;
   margin: 31px 0 17px 0;
-  width: calc(100vw * 0.6671875 + 40px);
+  width: ${props => props.isToggleOpen?'calc((100vw - 354px) * 0.818007662835249);':'calc((100vw - 144px) * 0.7597864768683274 + 40px);'}
   max-width: 1281px;
   justify-content: space-between;
   @media screen and (max-width: ${tabletL}){
@@ -55,7 +55,6 @@ export const Menu = styled.div`
   display: flex;
   width: 43px;
   align-items: center;
-  // margin-left: 1137px;
   padding: 8px;
   border: solid 1px ${lightgray};
   color: ${gray};
@@ -100,39 +99,41 @@ export const DivideLine = styled.img`
   margin: 0 9px;
 `;
 export const AlertProp = styled.div`
-  display: flex;
-  position: absolute;
-  right: 0px;
-  // margin-left: 19px;
+display: flex;
+position: absolute;
+right: 0px;
 `;
 export const StorageAlert = styled.li`
   display: flex;
-  width: calc(100vw * 0.6671875 + 40px);
+  width: ${props => props.isToggleOpen?'calc((100vw - 354px) * 0.818007662835249);':'calc((100vw - 144px) * 0.7597864768683274 + 40px);'}
   max-width: 1281px;
-  position: relative;
   color: ${darkgray};
   padding: 0 0 15px 0;
   margin: 15px 0 0 0;
   border-bottom: 1px solid ${lightgray};
+  position: relative;
   @media screen and (max-width:${tabletL}){
     width: 100%;
   }
 `;
 export const MemoAlertWrapper = styled.div`
   display: block;
-  width: calc(100vw * 0.6671875 + 40px);
+  width: 100%;
 `;
 export const AlertContent = styled.div`
   display: flex;
-  width: 100%;
-`;
+  width: ${props => props.isToggleOpen?'calc((100vw - 384px) * 0.4552864583333333);':'calc((100vw - 114px) * 0.4977851605758583 + 40px);'}
+  `;
 export const AlertTitle = styled.a`
-  width: 70.6440281030445%;
+width: 70.7017954722872756%;
+max-width: 899px;
+  height: 18px;
+  word-wrap : brek-word; 
   max-height: 18px;
-  font-size: 12px;
+  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
+  font-size: 12px;
   @media screen and (max-width: ${tabletL}){
     width: 100%;
     max-width: 100%;
@@ -152,6 +153,7 @@ export const MemoWrapper = styled.div`
 export const memoContent = styled.div`
   display: block;
   height: 73px;
+  width: 100%;
 `;
 export const MemoPanel = styled.div`
   position: relative;
@@ -171,6 +173,10 @@ export const LettterLength = styled.span``;
 export const KeyWordAlertList = styled.ol`
   height: calc(100vh - 337px);
   overflow-y: ${(props) => (props.scrollOption ? 'scroll' : 'none')};
+  &::-webkit-scrollbar { 
+    display: none;
+    width: 0px;
+  }
   @media screen and (max-width: ${tabletL}) {
     width: 100%;
     height: calc(100vh - 200px);

--- a/src/components/History/Scrap/Scrap.Style.js
+++ b/src/components/History/Scrap/Scrap.Style.js
@@ -174,7 +174,7 @@ export const KeyWordAlertList = styled.ol`
   overflow-y: ${(props) => (props.scrollOption ? 'scroll' : 'none')};
   @media screen and (max-width: ${tabletL}) {
     width: 100%;
-    height: 71vh;
+    height: calc(100vh - 200px);
     overflow-y: scroll;
     overflow-x: hidden;
   }

--- a/src/components/History/Scrap/Scrap.Style.js
+++ b/src/components/History/Scrap/Scrap.Style.js
@@ -107,7 +107,8 @@ export const AlertProp = styled.div`
 `;
 export const StorageAlert = styled.li`
   display: flex;
-  width: calc(100vw * 0.6671875);
+  width: calc(100vw * 0.6671875 + 40px);
+  max-width: 1281px;
   position: relative;
   color: ${darkgray};
   padding: 0 0 15px 0;
@@ -124,7 +125,6 @@ export const MemoAlertWrapper = styled.div`
 export const AlertContent = styled.div`
   display: flex;
   width: 100%;
-  justify-content: space-between;
 `;
 export const AlertTitle = styled.a`
   width: 70.6440281030445%;

--- a/src/components/History/Scrap/Scrap.Style.js
+++ b/src/components/History/Scrap/Scrap.Style.js
@@ -4,14 +4,14 @@ const {white, black, darkgray, lightgray, silver, gray, yellow} = theme.colors;
 
 const tabletL = theme.deviceSizes.tabletL;
 export const MemoBlock = styled.div`
-  width: 1033px;
+  width: 65.6440281030445%;
   border: none;
   resize: none;
   font-family: 'NotoSansCJKKR';
   font-size: 12px;
 `;
 export const WriteBlock = styled.textarea`
-  width: 1058px;
+  width: calc(100vw * 0.6671875 - 201px);
   height: 70px;
   border: none;
   resize: none;
@@ -101,12 +101,14 @@ export const DivideLine = styled.img`
 `;
 export const AlertProp = styled.div`
   display: flex;
-  margin-left: 19px;
+  position: absolute;
+  right: 0px;
+  // margin-left: 19px;
 `;
 export const StorageAlert = styled.li`
   display: flex;
-  width: 1279px;
-  justify-content: space-between;
+  width: calc(100vw * 0.6671875);
+  position: relative;
   color: ${darkgray};
   padding: 0 0 15px 0;
   margin: 15px 0 0 0;
@@ -117,16 +119,16 @@ export const StorageAlert = styled.li`
 `;
 export const MemoAlertWrapper = styled.div`
   display: block;
+  width: calc(100vw * 0.6671875 + 40px);
 `;
 export const AlertContent = styled.div`
   display: flex;
+  width: 100%;
   justify-content: space-between;
 `;
 export const AlertTitle = styled.a`
-  width: 884px;
-  
+  width: 70.6440281030445%;
   max-height: 18px;
-  margin-right: 45px;
   font-size: 12px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -151,13 +153,15 @@ export const memoContent = styled.div`
   display: block;
   height: 73px;
 `;
-
-export const LetterCounter = styled.div`
+export const MemoPanel = styled.div`
   position: relative;
+`
+export const LetterCounter = styled.div`
+  position: absolute;
+  width: 38px;
+  bottom: 23px;
+  right: 16px;
   text-align: right;
-  left: 990px;
-  bottom: 30px;
-  width: 52px;
   height: 20px;
   font-size: 12px;
 `;

--- a/src/components/History/Scrap/Scrap.Style.js
+++ b/src/components/History/Scrap/Scrap.Style.js
@@ -28,6 +28,11 @@ export const WriteBlock = styled.textarea`
 `;
 export const Content = styled.div`
   margin: 0 0 0 13px;
+  @media screen and (max-width: ${tabletL}) {
+    width: 100%;
+    margin: 0 auto;
+    top: 0;
+  }
 `;
 export const CheckBox = styled.div`
   display: flex;

--- a/src/components/History/Scrap/Scrap.Style.js
+++ b/src/components/History/Scrap/Scrap.Style.js
@@ -12,6 +12,7 @@ export const MemoBlock = styled.div`
 `;
 export const WriteBlock = styled.textarea`
   width: calc(100vw * 0.6671875 - 165px);
+  max-width: 1077px;
   height: 70px;
   border: none;
   resize: none;

--- a/src/components/History/Scrap/Scrap.Style.js
+++ b/src/components/History/Scrap/Scrap.Style.js
@@ -11,7 +11,7 @@ export const MemoBlock = styled.div`
   font-size: 12px;
 `;
 export const WriteBlock = styled.textarea`
-  width: calc(100vw * 0.6671875 - 201px);
+  width: calc(100vw * 0.6671875 - 165px);
   height: 70px;
   border: none;
   resize: none;

--- a/src/components/History/Scrap/Scrap.Style.js
+++ b/src/components/History/Scrap/Scrap.Style.js
@@ -26,13 +26,16 @@ export const WriteBlock = styled.textarea`
   }
 
 `;
+export const Content = styled.div`
+  margin: 0 0 0 13px;
+`;
 export const CheckBox = styled.div`
   display: flex;
   align-items: center;
 `;
 export const MenuList = styled.div`
   display: flex;
-  margin: 31px 0 32px 0;
+  margin: 31px 0 17px 0;
   @media screen and (max-width: ${tabletL}){
     width: 90%;
     justify-content: space-between;
@@ -45,6 +48,7 @@ export const MenuList = styled.div`
 `;
 export const Menu = styled.div`
   display: flex;
+  width: 43px;
   align-items: center;
   margin-left: 1137px;
   padding: 8px;
@@ -61,7 +65,7 @@ export const Menu = styled.div`
 export const MenuLogo = styled.img`
   width: 16px;
   height: 16px;
-  margin: 0 8px 0 0px;
+  margin-right: 4px;
 `;
 export const MenuName = styled.div`
   width: 25px;
@@ -79,6 +83,7 @@ export const Wrapper = styled.div`
 `;
 export const SelectAll = styled.div`
   width: 45px;
+  display: flex;
   margin-bottom: 6px;
 `;
 export const MemoOption = styled.div`
@@ -102,7 +107,7 @@ export const AlertProp = styled.div`
 `;
 export const StorageAlert = styled.li`
   display: flex;
-  width: 1294px;
+  width: 1279px;
   color: ${darkgray};
   padding: 0 0 15px 0;
   margin: 15px 0 0 0;
@@ -122,7 +127,7 @@ export const AlertContent = styled.div`
 
 `;
 export const AlertTitle = styled.a`
-  width: 899px;
+  width: 884px;
   
   max-height: 18px;
   margin-right: 45px;
@@ -167,7 +172,7 @@ export const LetterCounter = styled.div`
 export const LettterLength = styled.span``;
 
 export const KeyWordAlertList = styled.ol`
-  height: 600px;
+  height: calc(100vh - 337px);
   overflow-y: ${(props) => (props.scrollOption ? 'scroll' : 'none')};
   @media screen and (max-width: ${tabletL}) {
     width: 100%;

--- a/src/components/History/Scrap/Scrap.Style.js
+++ b/src/components/History/Scrap/Scrap.Style.js
@@ -31,8 +31,7 @@ export const Content = styled.div`
   margin: 0 0 0 13px;
   @media screen and (max-width: ${tabletL}) {
     width: 100%;
-    margin: 0 auto;
-    top: 0;
+    margin: 0px;
   }
 `;
 export const CheckBox = styled.div`
@@ -177,6 +176,10 @@ export const KeyWordAlertList = styled.ol`
     height: calc(100vh - 200px);
     overflow-y: scroll;
     overflow-x: hidden;
+    &::-webkit-scrollbar { 
+      display: none;
+      width: 0
+  }
   }
 `;
 

--- a/src/components/History/Scrap/Scrap.Style.js
+++ b/src/components/History/Scrap/Scrap.Style.js
@@ -41,30 +41,27 @@ export const CheckBox = styled.div`
 export const MenuList = styled.div`
   display: flex;
   margin: 31px 0 17px 0;
+  width: calc(100vw * 0.6671875 + 40px);
+  max-width: 1281px;
+  justify-content: space-between;
   @media screen and (max-width: ${tabletL}){
     width: 90%;
     justify-content: space-between;
     margin: 0 auto;
     margin-top: 17px;
   }
-  @media (min-width: ${(props)=>props.theme.deviceSizes.tabletL}) and (max-width: ${(props)=>props.theme.deviceSizes.NoteBook}){
-    width: 900px;
-  }
 `;
 export const Menu = styled.div`
   display: flex;
   width: 43px;
   align-items: center;
-  margin-left: 1137px;
+  // margin-left: 1137px;
   padding: 8px;
   border: solid 1px ${lightgray};
   color: ${gray};
   cursor: pointer;
   @media screen and (max-width: ${tabletL}){
     margin: 0;
-  }
-  @media (min-width: ${(props)=>props.theme.deviceSizes.tabletL}) and (max-width: ${(props)=>props.theme.deviceSizes.NoteBook}){
-    margin-left: 720px;
   }
 `;
 export const MenuLogo = styled.img`
@@ -80,10 +77,6 @@ export const Wrapper = styled.div`
   font-size: 12px;
   @media screen and (max-width: ${tabletL}){
     width: 100vw;
-  }
-  @media (min-width: ${(props)=>props.theme.deviceSizes.tabletL}) and (max-width: ${(props)=>props.theme.deviceSizes.NoteBook}){
-    width: 900px;
-    height: 400px;
   }
 `;
 export const SelectAll = styled.div`
@@ -121,9 +114,6 @@ export const StorageAlert = styled.li`
   @media screen and (max-width:${tabletL}){
     width: 100%;
   }
-  @media (min-width: ${(props)=>props.theme.deviceSizes.tabletL}) and (max-width: ${(props)=>props.theme.deviceSizes.NoteBook}){
-    width: 900px;
-  }
 `;
 export const MemoAlertWrapper = styled.div`
   display: block;
@@ -144,9 +134,6 @@ export const AlertTitle = styled.a`
   @media screen and (max-width: ${tabletL}){
     width: 100%;
     max-width: 100%;
-  }
-  @media (min-width: ${(props)=>props.theme.deviceSizes.tabletL}) and (max-width: ${(props)=>props.theme.deviceSizes.NoteBook}){
-    width: 550px;
   }
 `;
 

--- a/src/components/History/Scrap/ScrapContent.js
+++ b/src/components/History/Scrap/ScrapContent.js
@@ -212,20 +212,22 @@ const ScrapContent = () => {
                     {mail.userScrapId === currentMail ? null : <S.MemoCircle />}
                     {mail.userScrapId === currentMail && (pageState === 'FIX' || pageState === 'WRITE') ? (
                       <S.memoContent>
-                        <S.WriteBlock
-                          defaultValue={findMemoInAlert(memoItemList, mail)}
-                          onChange={(e) => checkByte(e)}
-                          maxLength={100}
-                          ref={fixMemoValue}
-                        />
-                        <S.LetterCounter>
-                          <S.LettterLength
-                            ref={letter}
-                          >
-                            {findMemoInAlert(memoItemList, mail)[0].length}
-                          </S.LettterLength>
-                          /100
-                        </S.LetterCounter>
+                        <S.MemoPanel>
+                          <S.WriteBlock
+                            defaultValue={findMemoInAlert(memoItemList, mail)}
+                            onChange={(e) => checkByte(e)}
+                            maxLength={100}
+                            ref={fixMemoValue}
+                          />
+                          <S.LetterCounter>
+                            <S.LettterLength
+                              ref={letter}
+                            >
+                              {findMemoInAlert(memoItemList, mail)[0].length}
+                            </S.LettterLength>
+                            /100
+                          </S.LetterCounter>
+                        </S.MemoPanel>
                       </S.memoContent>
                     ) : (
                       <S.MemoBlock>{makeStringToNewLine(findMemoInAlert(memoItemList, mail)[0])}</S.MemoBlock>

--- a/src/components/History/Scrap/ScrapContent.js
+++ b/src/components/History/Scrap/ScrapContent.js
@@ -40,7 +40,7 @@ const findMemoInAlert = (memoList, alert) => {
       return memo.memo;
     });
 };
-const ScrapContent = () => {
+const ScrapContent = ({isToggleOpen}) => {
   const { scrapList, memoList, getMemoListResponse, deleteScrapResponse, fixMemoResponse, writeMemoResponse } =
     useSelector((state) => state.scrap);
   const userInfo = useSelector((state) => state.auth);
@@ -161,7 +161,7 @@ const ScrapContent = () => {
     <>
     <S.Wrapper>
       <S.Content>
-      <S.MenuList>
+      <S.MenuList isToggleOpen={isToggleOpen}>
         <S.CheckBox>
           <HistoryCheckBox
             onClick={(e) => selectAll(e)}
@@ -186,15 +186,15 @@ const ScrapContent = () => {
                       setCurr={setCurr}
                       />
           :
-          <S.StorageAlert key={mail.id}>
+          <S.StorageAlert key={mail.id} isToggleOpen={isToggleOpen}>
             <HistoryCheckBox
               onClick={(e) => selectMail(e, mail.id)}
               checked={checkedList.includes(mail.id) ? true : false}
               readOnly
             />
             <Sender>{SITE_LIST[SITE_LIST.findIndex((site) => site.id === mail.site)].title}</Sender>
-            <S.MemoAlertWrapper>
-              <S.AlertContent>
+            <S.MemoAlertWrapper isToggleOpen={isToggleOpen}>
+              <S.AlertContent isToggleOpen={isToggleOpen}>
                 <S.AlertTitle href={mail.url}>{mail.title}</S.AlertTitle>
                 <S.AlertProp>
                   {memoIdList.includes(mail.userScrapId) ? (
@@ -218,6 +218,7 @@ const ScrapContent = () => {
                             onChange={(e) => checkByte(e)}
                             maxLength={100}
                             ref={fixMemoValue}
+                            isToggleOpen={isToggleOpen}
                           />
                           <S.LetterCounter>
                             <S.LettterLength

--- a/src/components/History/Scrap/ScrapContent.js
+++ b/src/components/History/Scrap/ScrapContent.js
@@ -160,6 +160,7 @@ const ScrapContent = () => {
   return (
     <>
     <S.Wrapper>
+      <S.Content>
       <S.MenuList>
         <S.CheckBox>
           <HistoryCheckBox
@@ -243,6 +244,8 @@ const ScrapContent = () => {
           </S.StorageAlert>
         ))}
       </S.KeyWordAlertList>
+      </S.Content>
+      
     </S.Wrapper>
     </>
   );

--- a/src/pages/HistoryPage.js
+++ b/src/pages/HistoryPage.js
@@ -13,7 +13,7 @@ const HistoryPageContent = styled.div`
   display: flex;
   height: 100%;
   overflow-y: hidden;
-  overflow-x: hidden;
+  // overflow-x: hidden;
   @media screen and (max-width: ${theme.deviceSizes.tabletL}) {
     width: 100vw;
     display: flex;

--- a/src/pages/HistoryPage.js
+++ b/src/pages/HistoryPage.js
@@ -30,7 +30,7 @@ const HistoryPageContent = styled.div`
 const ContentWrapper = styled.div`
   width: 100%;
   height: 100%;
-  margin: 121px 0 0 131px;
+  margin: ${props => props.isToggleOpen?'121px 0 0 100px;':'121px 0 0 131px;'}
   @media screen and (max-width: ${theme.deviceSizes.tabletL}) {
     position: fixed;
     height: 0%;
@@ -45,16 +45,15 @@ const HistoryPage = () => {
   const [mobile] = useMatchMedia(queries);
   const location = useLocation();
   const {isOpen} = useSelector((state) => state.toggle);
-  console.log(isOpen)
   return (
     <HistoryPageContent>
       <SideNavbar />
       {!mobile && <LoginButton />}
-      <ContentWrapper>
+      <ContentWrapper isToggleOpen={isOpen}>
         <HistoryHeader location={location} isToggleOpen={isOpen}/>
         <Routes>
           <Route path="/" element={<HistoryContent isToggleOpen={isOpen}/>} />
-          <Route path="/scrap" element={<ScrapContent />} />
+          <Route path="/scrap" element={<ScrapContent isToggleOpen={isOpen}/>} />
         </Routes>
       </ContentWrapper>
     </HistoryPageContent>

--- a/src/pages/HistoryPage.js
+++ b/src/pages/HistoryPage.js
@@ -3,6 +3,7 @@ import ScrapContent from 'components/History/Scrap/ScrapContent';
 import HistoryHeader from 'components/History/History/HistoryHeader';
 import React from 'react';
 import { Route, Routes, useLocation } from 'react-router-dom';
+import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 import SideNavbar from 'components/SideNavbar';
 import theme from 'theme';
@@ -43,14 +44,16 @@ const queries = [`(max-width: ${theme.deviceSizes.tabletL})`];
 const HistoryPage = () => {
   const [mobile] = useMatchMedia(queries);
   const location = useLocation();
+  const {isOpen} = useSelector((state) => state.toggle);
+  console.log(isOpen)
   return (
     <HistoryPageContent>
       <SideNavbar />
       {!mobile && <LoginButton />}
       <ContentWrapper>
-        <HistoryHeader location={location} />
+        <HistoryHeader location={location} isToggleOpen={isOpen}/>
         <Routes>
-          <Route path="/" element={<HistoryContent />} />
+          <Route path="/" element={<HistoryContent isToggleOpen={isOpen}/>} />
           <Route path="/scrap" element={<ScrapContent />} />
         </Routes>
       </ContentWrapper>


### PR DESCRIPTION
## 개요 <!-- 작업 내역 한줄 요약, 스크린샷 등 -->
![image](https://user-images.githubusercontent.com/71335694/160243617-671f1a7e-e1b8-4d5e-babd-f19074d04102.png)
![image](https://user-images.githubusercontent.com/71335694/160243634-1ff8f814-89d1-4c74-a145-ed5398c7de7a.png)
![image](https://user-images.githubusercontent.com/71335694/160243652-ea47666a-d8bc-4157-85de-985a53515a24.png)

![image](https://user-images.githubusercontent.com/71335694/160243643-5ab5d81e-ab33-41de-877e-8d63b665165f.png)


## 이슈 번호

- closes [#68  ]

## 변경사항 <!-- 필수, 상세히 작성(목록화 등)하면 간결한 코드리뷰가 가능해집니다 -->
보관함과 히스토리 스타일 수정하면서 전체적으로 반응형으로 수정했습니다. 테스트는 전부 완료했지만, 미처 확인 못한 부분도 있을 수 있어서 확인 한번 해주시면 감사하겠습니다
## 특이사항 <!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->
히스토리와 보관함 api 요청이 약간 바뀌어서 후에 따로 이슈 작성하여 수정할 예정입니다