### PR TITLE
로그인 회원가입 오류 시 

### DIFF
--- a/src/components/Auth/Find/FindId.js
+++ b/src/components/Auth/Find/FindId.js
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router';
-import { LOGIN } from 'constant';
+import { LOGIN, NOT_EXIST_ACCOUNT } from 'constant';
 import MobileTopBar from 'components/Shared/MobileTopBar';
 import MobileConfig from 'components/Shared/MobileConfig';
 import useMatchMedia from 'hooks/useMatchMedia';
@@ -20,7 +20,6 @@ const FindId = () => {
 
   const [isEmailError, setIsEmailError] = useState(true);
   const [isAuthNumError, setIsAuthNumError] = useState(true);
-
   const emailRef = useRef();
   const authRef = useRef();
 
@@ -71,6 +70,7 @@ const FindId = () => {
             <SubmitAccountForm>
               <IdfForm>
                 <EmailForm ref={emailRef} onChange={onChangeEmail} />
+
                 <AuthNumberForm
                   type="ACCOUNT"
                   ref={authRef}
@@ -129,7 +129,7 @@ const IdfForm = styled.div`
   }
 `;
 const NextButton = styled(Button)`
-  margin-top:120px;
+  margin-top: 120px;
   @media screen and (max-width: ${(props) => props.theme.deviceSizes.mobileL}) {
     width: 328px;
     position: absolute;
@@ -137,7 +137,7 @@ const NextButton = styled(Button)`
   }
 `;
 const CompleteButton = styled(Button)`
-  margin-top:0px;
+  margin-top: 0px;
   @media screen and (max-width: ${(props) => props.theme.deviceSizes.mobileL}) {
     width: 328px;
     position: absolute;
@@ -154,4 +154,7 @@ const FindAccountText = styled.div`
     text-align: left;
     color: ${(props) => props.theme.colors.darkgray};
   }
+`;
+const ErrorText = styled(S.InputErrorText)`
+  margin: 0;
 `;

--- a/src/components/Auth/Login/LoginForm.js
+++ b/src/components/Auth/Login/LoginForm.js
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
+import { LOGIN_ID_ERROR, LOGIN_PASSWORD_ERROR } from 'constant';
+import { resetAuthState } from 'store/auth';
 import styled from 'styled-components';
 import Switch from 'components/Shared/Switch';
 import StyledButton from 'components/Shared/Button';
@@ -48,6 +50,9 @@ const EyeImg = styled.img`
   width: 24px;
   height: 24px;
 `;
+const ErrorText = styled(S.InputErrorText)`
+  margin: 0;
+`;
 
 const LoginForm = () => {
   const dispatch = useDispatch();
@@ -58,13 +63,19 @@ const LoginForm = () => {
     type: 'password',
     visible: false,
   });
-
+  const authErrorCode = useSelector((state) => state.auth.authError);
   const accountHandler = (e) => {
     setAccount(e.target.value);
+    if (authErrorCode != null) {
+      dispatch(resetAuthState());
+    }
   };
 
   const passwordHandler = (e) => {
     setPassword(e.target.value);
+    if (authErrorCode != null) {
+      dispatch(resetAuthState());
+    }
   };
 
   /*
@@ -99,7 +110,14 @@ const LoginForm = () => {
     <>
       <LoginFormContainer onSubmit={submitHandler}>
         <StyledInputContainer>
-          <StyledInput value={account} onChange={accountHandler} name="account" placeholder="아이디 입력" />
+          <StyledInput
+            value={account}
+            onChange={accountHandler}
+            error={authErrorCode == LOGIN_ID_ERROR}
+            name="account"
+            placeholder="아이디 입력"
+          />
+          {authErrorCode == LOGIN_ID_ERROR && <ErrorText>아이디가 일치하지 않습니다.</ErrorText>}
         </StyledInputContainer>
 
         <StyledInputContainer>
@@ -107,12 +125,14 @@ const LoginForm = () => {
             value={password}
             type={isPasswordType.type}
             onChange={passwordHandler}
+            error={authErrorCode == LOGIN_PASSWORD_ERROR}
             name="password"
             placeholder="비밀번호 입력"
           />
           <PwdSee onClick={handlePasswordType}>
             <EyeImg src={'/asset/' + getPwdSvgName() + '.svg'} alt={getPwdSvgName()} />
           </PwdSee>
+          {authErrorCode == LOGIN_PASSWORD_ERROR && <ErrorText>비밀번호가 일치하지 않습니다.</ErrorText>}
         </StyledInputContainer>
 
         <S.AutoLogin>

--- a/src/components/Auth/Register/Register.js
+++ b/src/components/Auth/Register/Register.js
@@ -31,19 +31,19 @@ const RegisterForm = () => {
   const [password, setPassword] = useState('');
   const [passwordConfirm, setPasswordConfirm] = useState('');
   const [email, setEmail] = useState('');
-  const [nickName, setNickName] = useState('');
+  const [nickname, setNickname] = useState('');
 
   const [accountMessage, setAccountMessage] = useState('');
   const [emailMessage, setEmailMessage] = useState('');
   const [passwordMessage, setPasswordMessage] = useState('');
   const [passwordConfirmMessage, setPasswordConfirmMessage] = useState('');
-  const [nickNameMessage, setNickNameMessage] = useState('');
+  const [nicknameMessage, setNicknameMessage] = useState('');
 
   const [isAccount, setIsAccount] = useState(false);
   const [isEmail, setIsEmail] = useState(false);
   const [isPassword, setIsPassword] = useState(false);
   const [isPasswordConfirm, setIsPasswordConfirm] = useState(false);
-  const [isNickName, setIsNickName] = useState(false);
+  const [isNickname, setIsNickname] = useState(false);
 
   const [isDisabled, setIsDisabled] = useState(true);
   const [visible, setVisible] = useState(false);
@@ -52,7 +52,7 @@ const RegisterForm = () => {
   const onSubmit = (e) => {
     e.preventDefault();
     const find_email = email;
-    dispatch(signUp({ account, password, find_email, nickName }));
+    dispatch(signUp({ account, password, find_email, nickname }));
   };
 
   const onConfirm = () => {
@@ -118,37 +118,37 @@ const RegisterForm = () => {
     }
   }, []);
 
-  const onChangeNickName = useCallback((e) => {
-    setNickName(e.target.value);
-    if (e.target.value.length < 2 || e.target.value.length > 5) {
-      setNickNameMessage('2글자 이상 5글자 미만으로 입력해주세요.');
-      setIsNickName(false);
+  const onChangeNickname = useCallback((e) => {
+    setNickname(e.target.value);
+    if (e.target.value.length < 2 || e.target.value.length > 10) {
+      setNicknameMessage('2글자 이상 10글자 미만으로 입력해주세요.');
+      setIsNickname(false);
     } else {
-      setNickNameMessage('');
-      setIsNickName(true);
+      setNicknameMessage('');
+      setIsNickname(true);
     }
   }, []);
 
   useEffect(() => {
-    if (isAccount && isPassword && isPasswordConfirm && isEmail && isNickName) {
+    if (isAccount && isPassword && isPasswordConfirm && isEmail && isNickname) {
       setIsDisabled(false);
     } else {
       setIsDisabled(true);
     }
-  }, [isAccount, isPassword, isPasswordConfirm, isEmail, isNickName]);
+  }, [isAccount, isPassword, isPasswordConfirm, isEmail, isNickname]);
 
   useEffect(() => {
     if (errorCode == ACCOUNT_ERROR) {
-      setAccountMessage('이미 존재하는 계정입니다.');
+      setAccountMessage('이미 가입된 아이디입니다.');
       setIsAccount(false);
     } else if (errorCode == NICKNAME_ERROR) {
-      setNickNameMessage('이미 존재하는 닉네임입니다.');
-      setIsNickName(false);
+      setNicknameMessage('이미 사용중인 닉네임입니다.');
+      setIsNickname(false);
     } else if (errorCode == EMAIL_ERROR) {
       setEmailMessage('이미 존재하는 이메일 입니다.');
       setIsEmail(false);
     }
-    if (errorCode === '' && isAccount && isPassword && isPasswordConfirm && isEmail && isNickName) {
+    if (errorCode === 201 && isAccount && isPassword && isPasswordConfirm && isEmail && isNickname) {
       setVisible(true);
     }
   }, [errorCode]);
@@ -201,13 +201,13 @@ const RegisterForm = () => {
               errorMessage={emailMessage}
             />
             <CommonInput
-              name="nickName"
-              value={nickName}
-              onChange={onChangeNickName}
+              name="nickname"
+              value={nickname}
+              onChange={onChangeNickname}
               placeholder="닉네임"
-              error={nickNameMessage}
-              isError={nickNameMessage !== ''}
-              errorMessage={nickNameMessage}
+              error={nicknameMessage}
+              isError={nicknameMessage !== ''}
+              errorMessage={nicknameMessage}
             />
 
             <S.BottomProgressBar>

--- a/src/components/Auth/Register/Register.js
+++ b/src/components/Auth/Register/Register.js
@@ -52,7 +52,12 @@ const RegisterForm = () => {
   const onSubmit = (e) => {
     e.preventDefault();
     const find_email = email;
-    dispatch(signUp({ account, password, find_email, nickname }));
+    if (password === passwordConfirm) {
+      dispatch(signUp({ account, password, find_email, nickname }));
+    } else {
+      setPasswordConfirmMessage('비밀번호가 다릅니다');
+      setIsPasswordConfirm(false);
+    }
   };
 
   const onConfirm = () => {

--- a/src/components/Auth/Shared/EmailForm.js
+++ b/src/components/Auth/Shared/EmailForm.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useImperativeHandle } from 'react';
 import { useSelector } from 'react-redux';
-import { NOT_MATCH_EMAIL, NOT_SEND_EMAIL, EMAIL_REGEXP } from 'constant';
+import { NOT_MATCH_EMAIL, NOT_SEND_EMAIL, EMAIL_REGEXP, NOT_EXIST_ACCOUNT } from 'constant';
 import CommonInput from './CommonInput';
 
 const EmailForm = React.forwardRef((props, ref) => {
@@ -42,17 +42,21 @@ const EmailForm = React.forwardRef((props, ref) => {
       errorEmail(true, '가입할 때 설정한 찾기용 이메일과 일치하지 않습니다.');
     } else if (errorCode == NOT_SEND_EMAIL) {
       errorEmail(true, '먼저 이메일을 전송해주세요');
+    } else if (errorCode == NOT_EXIST_ACCOUNT) {
+      errorEmail(true, '존재하지 않는 이메일입니다.');
     }
   }, [errorCode]);
   return (
-    <CommonInput
-      ref={inputRef}
-      name="email"
-      onChange={onChange}
-      isError={isEmailError}
-      errorMessage={emailMessage}
-      placeholder="이메일 입력"
-    />
+    <>
+      <CommonInput
+        ref={inputRef}
+        name="email"
+        onChange={onChange}
+        isError={isEmailError}
+        errorMessage={emailMessage}
+        placeholder="이메일 입력"
+      />
+    </>
   );
 });
 

--- a/src/components/Auth/index.js
+++ b/src/components/Auth/index.js
@@ -31,11 +31,11 @@ const Box = styled.div`
 const AuthTemplate = ({ children }) => {
   const location = useLocation();
   const queries = ['(max-width: 450px)'];
-  const [mobile] = useMatchMedia(queries);
+  const [desktop] = useMatchMedia(queries);
   return (
     <AuthTemplateBlock>
       <Box>
-        {(location.pathname === '/auth' || !mobile) && (
+        {(location.pathname == '/auth' || !desktop) && (
           <S.MainLogo>
             <S.MainLogoImg />
           </S.MainLogo>

--- a/src/components/Auth/styles.js
+++ b/src/components/Auth/styles.js
@@ -7,7 +7,6 @@ export const MainLogo = styled.div`
   justify-content: center;
 
   @media screen and (max-width: ${(props) => props.theme.deviceSizes.mobileL}) {
-    display: none;
   }
 `;
 
@@ -29,7 +28,8 @@ export const MainLogoImg = styled.i`
 export const StyledInput = styled.input`
   width: 348px;
   height: 44px;
-  border: solid 1px ${(props) => props.theme.colors.silver};
+  border: ${(props) =>
+    props.error ? `solid 1px ${props.theme.colors.yellow}` : `solid 1px ${props.theme.colors.silver}`};
   flex-grow: 0;
   padding-left: 16px;
   margin: 2px 0;
@@ -109,13 +109,13 @@ export const StyledLink = styled(Link)`
 
 export const AutoLogin = styled.div`
   display: flex;
+  position: relative;
+  left: 78%;
   width: 84px;
-  top: 8px;
+
   align-items: center;
   z-index: 1;
-
   @media screen and (max-width: ${(props) => props.theme.deviceSizes.mobileL}) {
-    width: 113px;
   }
 `;
 
@@ -138,7 +138,7 @@ export const AutoLoginText = styled.label`
 
   @media screen and (max-width: ${(props) => props.theme.deviceSizes.mobileM}) {
     :after {
-      content: '로그인 상태 유지';
+      content: '자동 로그인';
     }
   }
 `;

--- a/src/constant/index.js
+++ b/src/constant/index.js
@@ -8,6 +8,8 @@ export const REFRESH_TOKEN = 'refresh_token';
 export const EMAIL_ERROR = '125';
 export const NICKNAME_ERROR = '124';
 export const ACCOUNT_ERROR = '123';
+export const LOGIN_ID_ERROR = '126';
+export const LOGIN_PASSWORD_ERROR = '127';
 export const NOT_EXIST_ACCOUNT = '128';
 export const NOT_MATCH_EMAIL = '143';
 export const NOT_SEND_EMAIL = '144';
@@ -83,11 +85,11 @@ export const MENU_ITEM = [
 export const SITE_LIST = [
   {
     id: 'PORTAL',
-    title: '아우누리'
+    title: '아우누리',
   },
   {
     id: 'DORM',
-    title: '아우미르'
-  }
-]
+    title: '아우미르',
+  },
+];
 export const queries = ['(max-width: 450px)', '(min-width: 800px)'];

--- a/src/constant/index.js
+++ b/src/constant/index.js
@@ -5,9 +5,9 @@ export const AUNURI = 'https://portal.koreatech.ac.kr';
 
 export const REFRESH_TOKEN = 'refresh_token';
 
-export const EMAIL_ERROR = '125';
 export const NICKNAME_ERROR = '124';
 export const ACCOUNT_ERROR = '123';
+export const EMAIL_ERROR = '125';
 export const LOGIN_ID_ERROR = '126';
 export const LOGIN_PASSWORD_ERROR = '127';
 export const NOT_EXIST_ACCOUNT = '128';

--- a/src/store/auth.js
+++ b/src/store/auth.js
@@ -182,7 +182,7 @@ const auth = handleActions(
     }),
     [LOGIN_FAILURE]: (state, { payload: error }) => ({
       ...state,
-      authError: error,
+      authError: error.response.data.code,
       isLoggedIn: false,
     }),
     [OAUTH]: (state) => ({

--- a/src/store/auth.js
+++ b/src/store/auth.js
@@ -65,11 +65,11 @@ export const socialLogin = createAction(SOCIAL_LOGIN, ({ snsType, deviceToken })
 }));
 
 export const refresh = createAction(REFRESH);
-export const signUp = createAction(SIGNUP, ({ account, password, find_email, nickName }) => ({
+export const signUp = createAction(SIGNUP, ({ account, password, find_email, nickname }) => ({
   account,
   password,
   find_email,
-  nickName,
+  nickname,
 }));
 export const sendFindPassword = createAction(SEND_FIND_PASSWORD, (account, email) => ({
   account,
@@ -229,7 +229,8 @@ const auth = handleActions(
     [SIGNUP_SUCCESS]: (state, { payload }) => ({
       ...state,
       ...payload,
-      errorCode: '',
+      isLoggedIn: false,
+      errorCode: 201,
     }),
     [SIGNUP_FALIURE]: (state, { payload: error }) => {
       return {
@@ -276,17 +277,17 @@ const auth = handleActions(
     }),
     [SEND_FIND_ACCOUNT_FAILURE]: (state, { payload: error }) => ({
       ...state,
-      errorCode: error.code,
+      errorCode: error.response.data.code,
       sendSuccess: false,
     }),
     [AUTH_FIND_ACCOUNT_SUCCESS]: (state, { payload }) => ({
       ...state,
-      errorCode: payload.code,
+      errorCode: payload.data.code,
       authSuccess: true,
     }),
     [AUTH_FIND_ACCOUNT_FAILURE]: (state, { payload: error }) => ({
       ...state,
-      errorCode: error.code,
+      errorCode: payload.data.code,
       authSuccess: false,
     }),
     [FIND_ACCOUNT_SUCCESS]: (state, { payload }) => ({

--- a/src/store/auth.js
+++ b/src/store/auth.js
@@ -241,38 +241,38 @@ const auth = handleActions(
     [SEND_FIND_PASSWORD_SUCCESS]: (state, { payload }) => ({
       ...state,
       ...payload,
-      errorCode: payload.code,
+      errorCode: payload.response.data.code,
       sendSuccess: true,
     }),
     [SEND_FIND_PASSWORD_FAILURE]: (state, { payload: error }) => ({
       ...state,
-      errorCode: error.code,
+      errorCode: error.response.data.code,
       sendSuccess: false,
     }),
     [AUTH_FIND_PASSWORD_SUCCESS]: (state, { payload }) => ({
       ...state,
-      errorCode: payload.code,
+      errorCode: payload.response.data.code,
       authSuccess: true,
     }),
     [AUTH_FIND_PASSWORD_FAILURE]: (state, { payload: error }) => ({
       ...state,
-      errorCode: error.code,
+      errorCode: error.response.data.code,
       authSuccess: false,
     }),
     [CHANGE_PASSWORD_SUCCESS]: (state, { payload }) => ({
       ...state,
-      errorCode: payload.code,
+      errorCode: payload.response.data.code,
       changeComplete: true,
     }),
     [CHANGE_PASSWORD_FAILURE]: (state, { payload: error }) => ({
       ...state,
-      errorCode: error.code,
+      errorCode: error.response.data.code,
       changeComplete: false,
     }),
     [SEND_FIND_ACCOUNT_SUCCESS]: (state, { payload }) => ({
       ...state,
       ...payload,
-      errorCode: payload.code,
+      errorCode: payload.response.data.code,
       sendSuccess: true,
     }),
     [SEND_FIND_ACCOUNT_FAILURE]: (state, { payload: error }) => ({
@@ -287,7 +287,7 @@ const auth = handleActions(
     }),
     [AUTH_FIND_ACCOUNT_FAILURE]: (state, { payload: error }) => ({
       ...state,
-      errorCode: payload.data.code,
+      errorCode: error.response.data.code,
       authSuccess: false,
     }),
     [FIND_ACCOUNT_SUCCESS]: (state, { payload }) => ({
@@ -296,7 +296,7 @@ const auth = handleActions(
     }),
     [FIND_ACCOUNT_FAILURE]: (state, { payload: error }) => ({
       ...state,
-      errorCode: error.code,
+      errorCode: error.response.data.code,
     }),
     [GUEST]: (state) => ({
       ...state,
@@ -309,7 +309,7 @@ const auth = handleActions(
     }),
     [GUEST_FALIURE]: (state, { payload: error }) => ({
       ...state,
-      authError: error.code,
+      authError: error.response.data.code,
       isLoggedIn: false,
     }),
   },


### PR DESCRIPTION
## 개요 <!-- 작업 내역 한줄 요약, 스크린샷 등 -->
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/50792467/160274009-bd398d1c-fe10-46e9-af9d-520f9ef7b2ce.png">
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/50792467/160274025-8ecbeb86-6425-4134-88f5-21393051f7a6.png">
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/50792467/160274077-5ebcd094-f835-49e6-a52c-bf7e6814c146.png">
<img width="327" alt="image" src="https://user-images.githubusercontent.com/50792467/160274112-67e04858-0bf2-4769-a95f-1bbb34c5b815.png">

## 이슈 번호

- closes [#73]

## 변경사항 <!-- 필수, 상세히 작성(목록화 등)하면 간결한 코드리뷰가 가능해집니다 -->
모바일 버전과 웹 버전에 대한 로그인 에러를 출력을 수정하였습니다.
로그인 화면 : 존재하지 않는 아이디로 로그인 시, 아이디는 맞지만 비밀번호가 틀렸을 시
회원가입 : 존재하는 아이디인 경우, 비밀번호와 비밀번호 확인이 서로 다른 경우에 회원가입 되는 경우
사용중인 이메일인 경우, 이미 존재하는 닉네임인 경우
아이디 찾기 : 사용중인 이메일이 아닌 경우
비밀번호 찾기 : 존재하지 않는 계정, 사용중인 이메일과 다른 경우, 존재하지 않는 이메일인 경우

## 특이사항 <!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->
최근 로그인 회원가입이 제대로 되지 않은 이유는 createRequestSaga에서 error.response.data가 error로 변경되어
있었습니다. 
공동으로 사용하는 로직 변경은 최소한으로 부탁드립니다.