### PR TITLE
히스토리 및 보관함 페이지 컴포넌트 분리/버그 수정

### DIFF
--- a/src/components/History/History/HistoryAlert.js
+++ b/src/components/History/History/HistoryAlert.js
@@ -26,8 +26,8 @@ const HistoryAlert = ({isToggleOpen, selectMail, checkedList, isMobile, mail}) =
         <>
           <S.KeyWordAlert isRead={isClicked} key={mail.id} isToggleOpen={isToggleOpen}>
             <HistoryCheckBox
-              onClick={(e) => selectMail(e, mail.id)}
-              checked={checkedList.includes(mail.id) ? true : false}
+              onClick={(e) => selectMail(e, mail.crawlingId)}
+              checked={checkedList.includes(mail.crawlingId) ? true : false}
               readOnly
             />
             <S.AlertContent>

--- a/src/components/History/History/HistoryAlert.js
+++ b/src/components/History/History/HistoryAlert.js
@@ -22,7 +22,6 @@ const HistoryAlert = ({isToggleOpen, selectMail, checkedList, isMobile, mail}) =
             setClick(!isClicked)
         }
     };
-    console.log(mail.id, mail.isRead)
     return (
         <>
           <S.KeyWordAlert isRead={isClicked} key={mail.id} isToggleOpen={isToggleOpen}>

--- a/src/components/History/History/HistoryAlert.js
+++ b/src/components/History/History/HistoryAlert.js
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import HistoryCheckBox from './HisoryCheckBox';
+import * as S from './History.Style';
+import { SITE_LIST } from 'constant';
+import { useDispatch, useSelector } from 'react-redux';
+import { readHistoryItem } from 'store/history';
+
+export const formatingDate = (date) => {
+    const newDate = new Date(date);
+    const month = newDate.getMonth() + 1 < 10 ? '0' + (newDate.getMonth() + 1) : newDate.getMonth() + 1;
+    const day = newDate.getDate() < 10 ? '0' + newDate.getDate() : newDate.getDate();
+    const hour = newDate.getHours() < 10 ? '0' + newDate.getHours() : newDate.getHours();
+    const minute = newDate.getMinutes() < 10 ? '0' + newDate.getMinutes() : newDate.getMinutes();
+    return `${month + '/' + day} - ${(hour === 0 ? '00' : hour) + ':' + (minute===0?'00':minute)}`;
+  };
+const HistoryAlert = ({isToggleOpen, selectMail, checkedList, isMobile, mail}) => {
+    const dispatch = useDispatch()
+    const [isClicked, setClick] = useState(mail.isRead);
+    const clickMail = (id) => {
+        if(!isClicked){
+            dispatch(readHistoryItem(id));
+            setClick(!isClicked)
+        }
+    };
+    console.log(mail.id, mail.isRead)
+    return (
+        <>
+          <S.KeyWordAlert isRead={isClicked} key={mail.id} isToggleOpen={isToggleOpen}>
+            <HistoryCheckBox
+              onClick={(e) => selectMail(e, mail.id)}
+              checked={checkedList.includes(mail.id) ? true : false}
+              readOnly
+            />
+            <S.AlertContent>
+              <S.AlertDetail>
+                <S.Sender>{SITE_LIST[SITE_LIST.findIndex((site) => site.id === mail.site)].title}</S.Sender>
+                {isMobile && <S.ReceiveDate>{formatingDate(mail.createdAt)}</S.ReceiveDate>}
+              </S.AlertDetail>
+              <S.AlertTitle href={mail.url} isRead={isClicked} target='_blank' onClick={(e) => clickMail(mail.id)} isToggleOpen={isToggleOpen}>
+                {mail.title}
+              </S.AlertTitle>
+            </S.AlertContent>
+            {!isMobile && (
+              <S.AlertInfo>
+                <S.MailBrowse>{isClicked ? '읽음' : '읽지않음'}</S.MailBrowse>
+                <S.ReceiveDate>{formatingDate(mail.createdAt)}</S.ReceiveDate>
+              </S.AlertInfo>
+            )}
+          </S.KeyWordAlert>
+          {isMobile && <S.AlertBorderBox />}
+        </>
+      )
+}
+
+export default HistoryAlert

--- a/src/components/History/History/HistoryAlert.js
+++ b/src/components/History/History/HistoryAlert.js
@@ -26,8 +26,8 @@ const HistoryAlert = ({isToggleOpen, selectMail, checkedList, isMobile, mail}) =
         <>
           <S.KeyWordAlert isRead={isClicked} key={mail.id} isToggleOpen={isToggleOpen}>
             <HistoryCheckBox
-              onClick={(e) => selectMail(e, mail.crawlingId)}
-              checked={checkedList.includes(mail.crawlingId) ? true : false}
+              onClick={(e) => selectMail(e, mail)}
+              checked={checkedList.includes(mail) ? true : false}
               readOnly
             />
             <S.AlertContent>

--- a/src/components/History/History/HistoryContent.js
+++ b/src/components/History/History/HistoryContent.js
@@ -70,15 +70,14 @@ const HistoryContent = ({isToggleOpen}) => {
     }
   }, [inView, readHistoryItemResponse, deleteHistoryResponse, undoHistoryListResponse, historyList]);
   useEffect(() => {
-    if (!historyList || historyList.length <= 0) {
-      return;
-    } else {
-      if(historyList[historyList.length-1]!==null){
-        setList(alertList.concat(historyList));
+      if(historyList!==null){
+        if(historyList.length === 0){
+          setList([])
+        }else{
+          setList(alertList.concat(historyList));
+        }
       }
-    }
   }, [historyList]);
-
   useEffect(() => {
     switch (command) {
       case 'read':

--- a/src/components/History/History/HistoryContent.js
+++ b/src/components/History/History/HistoryContent.js
@@ -5,7 +5,6 @@ import * as S from './History.Style';
 import {
   getHistoryList,
   deleteHistoryList,
-  readHistoryItem,
   moveToScrap,
   clearHistoryList,
   undoHistoryList,
@@ -18,14 +17,7 @@ import { useMediaQuery } from 'react-responsive';
 import theme from '../../../theme';
 import MobileMenuModal from './MobileMenuModal';
 import { MobileDeleteModal, MobileMoveScrapModal } from './MobilePopUpModal';
-export const formatingDate = (date) => {
-  const newDate = new Date(date);
-  const month = newDate.getMonth() + 1 < 10 ? '0' + (newDate.getMonth() + 1) : newDate.getMonth() + 1;
-  const day = newDate.getDate() < 10 ? '0' + newDate.getDate() : newDate.getDate();
-  const hour = newDate.getHours() < 10 ? '0' + newDate.getHours() : newDate.getHours();
-  const minute = newDate.getMinutes() < 10 ? '0' + newDate.getMinutes() : newDate.getMinutes();
-  return `${month + '/' + day} - ${(hour === 0 ? '00' : hour) + ':' + (minute===0?'00':minute)}`;
-};
+import HistoryAlert from './HistoryAlert';
 const HistoryContent = ({isToggleOpen}) => {
   const { historyList, deleteHistoryResponse, readHistoryItemResponse, moveToScrapResponse, undoHistoryListResponse } =
     useSelector((state) => state.history);
@@ -120,9 +112,6 @@ const HistoryContent = ({isToggleOpen}) => {
       setCheckedList(checkedList.filter((mailId) => mailId !== id));
     }
   };
-  const clickMail = (id) => {
-    dispatch(readHistoryItem(id));
-  };
   const closePopUp = () => {
     setOpen(false);
   };
@@ -212,7 +201,6 @@ const HistoryContent = ({isToggleOpen}) => {
   }, [isMobileDeleteOpen, isMobileScrapOpen]);
   return (
     <>
-    
       <S.PageWrapper onClick={isMobile ? closeMobileMenu : null}>
       {!isMobile && <PopUp isOpen={isPopOpen} closePopUp={closePopUp} />}
         <S.Content isOpen={isPopOpen}>
@@ -270,56 +258,29 @@ const HistoryContent = ({isToggleOpen}) => {
             </S.MenuWrapper>
           </S.MenuList>
           <S.KeyWordAlertList>
-            {showList?.map((mail, id) =>
+            {showList?.map((mail) =>
               showList[showList.length - 1].id === mail.id ? (
-                <S.KeyWordAlert isRead={mail.isRead} key={mail.id} ref={refAlert} isToggleOpen={isToggleOpen}>
-                  <HistoryCheckBox
-                    onClick={(e) => selectMail(e, mail.id)}
-                    checked={checkedList.includes(mail.id) ? true : false}
-                    readOnly
+                <div ref={refAlert} key={mail.id}>
+                  <HistoryAlert
+                    isToggleOpen={isToggleOpen}
+                    selectMail={selectMail}
+                    checkedList={checkedList}
+                    isMobile={isMobile}
+                    mail={mail}
                   />
-                  <S.AlertContent>
-                    <S.AlertDetail>
-                      <S.Sender>{SITE_LIST[SITE_LIST.findIndex((site) => site.id === mail.site)].title}</S.Sender>
-                      {isMobile && <S.ReceiveDate>{formatingDate(mail.createdAt)}</S.ReceiveDate>}
-                    </S.AlertDetail>
-                    <S.AlertTitle href={mail.url} isRead={mail.isRead} target='_blank' onClick={(e) => clickMail(mail.id)} isToggleOpen={isToggleOpen}>
-                      {mail.title}
-                    </S.AlertTitle>
-                  </S.AlertContent>
-                  {!isMobile && (
-                      <S.AlertInfo>
-                        <S.MailBrowse>{mail.isRead ? '읽음' : '읽지않음'}</S.MailBrowse>
-                        <S.ReceiveDate>{formatingDate(mail.createdAt)}</S.ReceiveDate>
-                      </S.AlertInfo>
-                    )}
-                </S.KeyWordAlert>
+                </div>
+
               ) : (
-                <>
-                  <S.KeyWordAlert isRead={mail.isRead} key={mail.id} isToggleOpen={isToggleOpen}>
-                    <HistoryCheckBox
-                      onClick={(e) => selectMail(e, mail.id)}
-                      checked={checkedList.includes(mail.id) ? true : false}
-                      readOnly
-                    />
-                    <S.AlertContent>
-                      <S.AlertDetail>
-                        <S.Sender>{SITE_LIST[SITE_LIST.findIndex((site) => site.id === mail.site)].title}</S.Sender>
-                        {isMobile && <S.ReceiveDate>{formatingDate(mail.createdAt)}</S.ReceiveDate>}
-                      </S.AlertDetail>
-                      <S.AlertTitle href={mail.url} isRead={mail.isRead} target='_blank' onClick={(e) => clickMail(mail.id)} isToggleOpen={isToggleOpen}>
-                        {mail.title}
-                      </S.AlertTitle>
-                    </S.AlertContent>
-                    {!isMobile && (
-                      <S.AlertInfo>
-                        <S.MailBrowse>{mail.isRead ? '읽음' : '읽지않음'}</S.MailBrowse>
-                        <S.ReceiveDate>{formatingDate(mail.createdAt)}</S.ReceiveDate>
-                      </S.AlertInfo>
-                    )}
-                  </S.KeyWordAlert>
+                <div key={mail.id}>
+                 <HistoryAlert
+                  isToggleOpen={isToggleOpen}
+                  selectMail={selectMail}
+                  checkedList={checkedList}
+                  isMobile={isMobile}
+                  mail={mail}
+                />
                   {isMobile && <S.AlertBorderBox />}
-                </>
+                </div>
               )
             )}
           </S.KeyWordAlertList>

--- a/src/components/History/History/HistoryContent.js
+++ b/src/components/History/History/HistoryContent.js
@@ -30,20 +30,16 @@ const HistoryContent = ({isToggleOpen}) => {
   const isMobile = useMediaQuery({ query: `(max-width:${theme.deviceSizes.tabletL}` });
   const selectAllMail = (e) => {
     if (e.target.checked) {
-      setCheckedList(
-        alertList.map((mail) => {
-          return mail.crawlingId;
-        })
-      );
+      setCheckedList(alertList);
     } else {
       setCheckedList([]);
     }
   };
-  const selectMail = (e, id) => {
+  const selectMail = (e, mail) => {
     if (e.target.checked) {
-      setCheckedList([...checkedList, id]);
+      setCheckedList([...checkedList, mail]);
     } else {
-      setCheckedList(checkedList.filter((mailId) => mailId !== id));
+      setCheckedList(checkedList.filter((element) => mail.id !== element.id));
     }
   };
   const closePopUp = () => {
@@ -53,13 +49,16 @@ const HistoryContent = ({isToggleOpen}) => {
     setMobileMenu(false);
   };
   useEffect(() => {
+    if(userInfo.isLoggedIn){
+      dispatch(clearHistoryList())
+      dispatch(getHistoryList(1));
+    }
+  },[])
+  useEffect(() => {
     if (userInfo.isLoggedIn || deleteHistoryResponse || readHistoryItemResponse || moveToScrapResponse) {
       dispatch(getHistoryList(pageNum[0]));
     }
   }, [userInfo.isLoggedIn, pageNum]);
-  useEffect(() => {
-    dispatch(clearHistoryList())
-  },[])
   useEffect(() => {
     if (!historyList || historyList.length <= 0) {
       return;
@@ -87,14 +86,10 @@ const HistoryContent = ({isToggleOpen}) => {
   }, [alertList, command]);
 
   useEffect(() => {
-    if (historyList.length === 0) {
-      setPageNum([1]);
-    }
     if (inView) {
       if(historyList[historyList.length-1]!==null){
         setPageNum([pageNum[0] + 1]);
       }
-      
     }
   }, [inView, readHistoryItemResponse, deleteHistoryResponse, undoHistoryListResponse, historyList]);
 
@@ -115,6 +110,7 @@ const HistoryContent = ({isToggleOpen}) => {
             setCommand={setCommand}
             isMobileMenuOpen={isMobileMenuOpen}
             setMobileMenu={setMobileMenu}
+            setPageNum={setPageNum}
           />
           <S.KeyWordAlertList>
             {showList?.map((mail) =>

--- a/src/components/History/History/HistoryContent.js
+++ b/src/components/History/History/HistoryContent.js
@@ -76,11 +76,7 @@ const HistoryContent = ({isToggleOpen}) => {
       if(historyList[historyList.length-1]!==null){
         setList(alertList.concat(historyList));
       }
-      // else{
-      //   setList((historyList.slice(0, historyList.length-1)));
-      // }
     }
-    console.log(alertList, pageNum[0])
   }, [historyList]);
 
   useEffect(() => {

--- a/src/components/History/History/HistoryContent.js
+++ b/src/components/History/History/HistoryContent.js
@@ -98,7 +98,7 @@ const HistoryContent = ({isToggleOpen}) => {
     if (e.target.checked) {
       setCheckedList(
         alertList.map((mail) => {
-          return mail.id;
+          return mail.crawlingId;
         })
       );
     } else {

--- a/src/components/History/History/HistoryContent.js
+++ b/src/components/History/History/HistoryContent.js
@@ -283,7 +283,7 @@ const HistoryContent = ({isToggleOpen}) => {
                       <S.Sender>{SITE_LIST[SITE_LIST.findIndex((site) => site.id === mail.site)].title}</S.Sender>
                       {isMobile && <S.ReceiveDate>{formatingDate(mail.createdAt)}</S.ReceiveDate>}
                     </S.AlertDetail>
-                    <S.AlertTitle href={mail.url} isRead={mail.isRead} onClick={(e) => clickMail(mail.id)} isToggleOpen={isToggleOpen}>
+                    <S.AlertTitle href={mail.url} isRead={mail.isRead} target='_blank' onClick={(e) => clickMail(mail.id)} isToggleOpen={isToggleOpen}>
                       {mail.title}
                     </S.AlertTitle>
                   </S.AlertContent>
@@ -307,7 +307,7 @@ const HistoryContent = ({isToggleOpen}) => {
                         <S.Sender>{SITE_LIST[SITE_LIST.findIndex((site) => site.id === mail.site)].title}</S.Sender>
                         {isMobile && <S.ReceiveDate>{formatingDate(mail.createdAt)}</S.ReceiveDate>}
                       </S.AlertDetail>
-                      <S.AlertTitle href={mail.url} isRead={mail.isRead} onClick={(e) => clickMail(mail.id)} isToggleOpen={isToggleOpen}>
+                      <S.AlertTitle href={mail.url} isRead={mail.isRead} target='_blank' onClick={(e) => clickMail(mail.id)} isToggleOpen={isToggleOpen}>
                         {mail.title}
                       </S.AlertTitle>
                     </S.AlertContent>

--- a/src/components/History/History/HistoryContent.js
+++ b/src/components/History/History/HistoryContent.js
@@ -50,25 +50,37 @@ const HistoryContent = ({isToggleOpen}) => {
   };
   useEffect(() => {
     if(userInfo.isLoggedIn){
-      dispatch(clearHistoryList())
+      dispatch(clearHistoryList());
       dispatch(getHistoryList(1));
     }
   },[])
   useEffect(() => {
     if (userInfo.isLoggedIn || deleteHistoryResponse || readHistoryItemResponse || moveToScrapResponse) {
+      if(pageNum[0]===1){
+        dispatch(clearHistoryList())
+      }
       dispatch(getHistoryList(pageNum[0]));
     }
-  }, [userInfo.isLoggedIn, pageNum]);
+  }, [pageNum]);
+  useEffect(() => {
+    if (inView) {
+      if(historyList !== null){
+        setPageNum([pageNum[0] + 1]);
+      }
+    }
+  }, [inView, readHistoryItemResponse, deleteHistoryResponse, undoHistoryListResponse, historyList]);
   useEffect(() => {
     if (!historyList || historyList.length <= 0) {
       return;
     } else {
       if(historyList[historyList.length-1]!==null){
-        setList(historyList);
-      }else{
-        setList((historyList.slice(0, historyList.length-1)));
+        setList(alertList.concat(historyList));
       }
+      // else{
+      //   setList((historyList.slice(0, historyList.length-1)));
+      // }
     }
+    console.log(alertList, pageNum[0])
   }, [historyList]);
 
   useEffect(() => {
@@ -84,14 +96,6 @@ const HistoryContent = ({isToggleOpen}) => {
         break;
     }
   }, [alertList, command]);
-
-  useEffect(() => {
-    if (inView) {
-      if(historyList[historyList.length-1]!==null){
-        setPageNum([pageNum[0] + 1]);
-      }
-    }
-  }, [inView, readHistoryItemResponse, deleteHistoryResponse, undoHistoryListResponse, historyList]);
 
   return (
     <>
@@ -111,6 +115,7 @@ const HistoryContent = ({isToggleOpen}) => {
             isMobileMenuOpen={isMobileMenuOpen}
             setMobileMenu={setMobileMenu}
             setPageNum={setPageNum}
+            alertList={alertList}
           />
           <S.KeyWordAlertList>
             {showList?.map((mail) =>
@@ -122,6 +127,7 @@ const HistoryContent = ({isToggleOpen}) => {
                     checkedList={checkedList}
                     isMobile={isMobile}
                     mail={mail}
+                    alertList={alertList}
                   />
                 </div>
 

--- a/src/components/History/History/HistoryMenuBar.js
+++ b/src/components/History/History/HistoryMenuBar.js
@@ -6,7 +6,7 @@ import { deleteScrapItem } from 'store/scrap';
 import { useDispatch } from "react-redux";
 import { MobileMoveScrapModal, MobileDeleteModal } from "./MobilePopUpModal";
 import MobileMenuModal from './MobileMenuModal';
-const HistoryMenuBar = ({selectAllMail,checkedList,setCheckedList,showList,setList,setOpen,isMobile,setCommand,command,isMobileMenuOpen,setMobileMenu,setPageNum}) => {
+const HistoryMenuBar = ({selectAllMail,checkedList,setCheckedList,showList,setList,setOpen,isMobile,setCommand,command,isMobileMenuOpen,setMobileMenu,setPageNum, alertList}) => {
     const dispatch = useDispatch()
     const [undoList, setUndoList] = useState([]);
     const [isMobileDeleteOpen, setMobileDeleteModal] = useState(false);
@@ -58,10 +58,10 @@ const HistoryMenuBar = ({selectAllMail,checkedList,setCheckedList,showList,setLi
               deleteMailQuery += `notice-id=${mail.id}&`;
             });
             dispatch(deleteHistoryList(deleteMailQuery));
-            setUndoList(checkedList);
+            console.log(checkedList.map((mail) => {return {mail: mail, index: alertList.indexOf(mail)}}))
+            setUndoList(checkedList.map((mail) => {return {mail: mail, index: alertList.indexOf(mail)}}));
             setCheckedList([]);
-            setPageNum([1]);
-            dispatch(clearHistoryList())
+            setList(alertList.filter((mail) => checkedList.map((element) => element.id).indexOf(mail.id) === -1))
           } catch (e) {
             console.log(e);
           } finally {
@@ -76,36 +76,26 @@ const HistoryMenuBar = ({selectAllMail,checkedList,setCheckedList,showList,setLi
       const undoDelete = () => {
         var undoMailQuery = '';
         try {
-          undoList.forEach((mail) => {
-            undoMailQuery += `notice-id=${mail.id}&`;
+          undoList.forEach((element) => {
+            undoMailQuery += `notice-id=${element.mail.id}&`;
           });
           dispatch(undoHistoryList(undoMailQuery));
-          setPageNum([1]);
         } catch (e) {
           console.log(e);
         } finally {
           setUndoList([]);
-          setList([]);
+          var redoList = alertList
+          undoList.forEach((mail) => {
+            redoList.splice(mail.index, 0, mail.mail)
+          })
+          console.log(redoList)
+          setList(redoList);
           setMobileDeleteModal(false);
-          dispatch(clearHistoryList())
         }
       };
       const openMobileMenu = () => {
         setMobileMenu(!isMobileMenuOpen);
       };
-      useEffect(() => {
-        if (isMobileDeleteOpen) {
-          setTimeout(() => {
-            setMobileDeleteModal(false);
-            setUndoList([]);
-          }, 4000);
-        } else if (isMobileScrapOpen) {
-          setTimeout(() => {
-            setMobileScrapModal(false);
-            setUndoList([]);
-          }, 4000);
-        }
-      }, [isMobileDeleteOpen, isMobileScrapOpen]);
     return(
         <S.MenuList>
             <S.CheckBox>

--- a/src/components/History/History/HistoryMenuBar.js
+++ b/src/components/History/History/HistoryMenuBar.js
@@ -1,0 +1,161 @@
+import React,{useState,useEffect} from "react";
+import * as S from './History.Style';
+import HistoryCheckBox from './HisoryCheckBox';
+import { moveToScrap, undoHistoryList, deleteHistoryList } from "store/history";
+import { deleteScrapItem } from 'store/scrap';
+import { useDispatch } from "react-redux";
+import { MobileMoveScrapModal, MobileDeleteModal } from "./MobilePopUpModal";
+import MobileMenuModal from './MobileMenuModal';
+const HistoryMenuBar = ({selectAllMail,checkedList,setCheckedList,showList,setList,setOpen,isMobile,setCommand,command,isMobileMenuOpen,setMobileMenu}) => {
+    const dispatch = useDispatch()
+    const [undoList, setUndoList] = useState([]);
+    const [isMobileDeleteOpen, setMobileDeleteModal] = useState(false);
+    const [isMobileScrapOpen, setMobileScrapModal] = useState(false);
+    const showRead = () => {
+        if (command === 'read') {
+          setCommand(null);
+        } else {
+          setCommand('read');
+        }
+      };
+      const showNotRead = () => {
+        if (command === 'notRead') {
+          setCommand(null);
+        } else {
+          setCommand('notRead');
+        }
+      };
+    const moveToStorage = () => {
+        if (checkedList.length > 0) {
+          try {
+            checkedList.forEach((id) => {
+              dispatch(moveToScrap({ crawling_id: id }));
+            });
+            setUndoList(checkedList);
+            setCheckedList([]);
+          } catch (e) {
+            console.log(e);
+          } finally {
+            if (isMobile) {
+              setMobileScrapModal(true);
+            } else {
+              setOpen(true);
+            }
+          }
+        } else {
+          alert('이동할 메일을 선택해 주세요');
+        }
+      };
+    const undoMoveScrap = () => {
+        dispatch(deleteScrapItem(undoList));
+        setUndoList([]);
+    };
+    const deleteMail = () => {
+        if (checkedList.length > 0) {
+          try {
+            var deleteMailQuery = '';
+            checkedList.forEach((id) => {
+              deleteMailQuery += `notice-id=${id}&`;
+            });
+            dispatch(deleteHistoryList(deleteMailQuery));
+            setUndoList([checkedList]);
+            setCheckedList([]);
+          } catch (e) {
+            console.log(e);
+          } finally {
+            if (isMobile) {
+              setMobileDeleteModal(true);
+            }
+          }
+        } else {
+          alert('삭제할 메일을 선택해 주세요');
+        }
+      };
+      const undoDelete = () => {
+        var undoMailQuery = '';
+        try {
+          undoList.forEach((id) => {
+            undoMailQuery += `notice-id=${id}&`;
+          });
+          dispatch(undoHistoryList(undoMailQuery));
+        } catch (e) {
+          console.log(e);
+        } finally {
+          setUndoList([]);
+          setList([]);
+          setMobileDeleteModal(false);
+        }
+      };
+      const openMobileMenu = () => {
+        setMobileMenu(!isMobileMenuOpen);
+      };
+      useEffect(() => {
+        if (isMobileDeleteOpen) {
+          setTimeout(() => {
+            setMobileDeleteModal(false);
+            setUndoList([]);
+          }, 4000);
+        } else if (isMobileScrapOpen) {
+          setTimeout(() => {
+            setMobileScrapModal(false);
+            setUndoList([]);
+          }, 4000);
+        }
+      }, [isMobileDeleteOpen, isMobileScrapOpen]);
+    return(
+        <S.MenuList>
+            <S.CheckBox>
+                <HistoryCheckBox
+                    onClick={(e) => selectAllMail(e)}
+                    checked={checkedList.length <= 0 || checkedList.length !== showList.length ? false : true}
+                    readOnly
+                    />
+                <S.SelectAll>
+                    전체선택
+                </S.SelectAll>
+            </S.CheckBox>
+        
+            <S.MenuWrapper onClick={(e) => e.stopPropagation()}>
+                {!isMobile && (
+                <>
+                    <S.Menues onClick={() => showRead()} isClicked={command === 'read' ? true : false}>
+                    <S.MenuName>읽은 알림</S.MenuName>
+                    </S.Menues>
+                    <S.Menues onClick={() => showNotRead()} isClicked={command === 'notRead' ? true : false}>
+                    <S.MenuName>읽지 않은 알림</S.MenuName>
+                    </S.Menues>
+                </>
+                )}
+                <S.Menues onClick={() => moveToStorage()}>
+                <S.MenuLogo src="/asset/Storage.svg" />
+                <S.MenuName>{!isMobile ? '보관함으로이동' : '보관'}</S.MenuName>
+                <div onClick={(e) => e.stopPropagation()}>
+                    {isMobile && isMobileScrapOpen && (
+                    <MobileMoveScrapModal numberAlert={undoList.length} undo={undoMoveScrap} />
+                    )}
+                </div>
+                </S.Menues>
+                <S.Menues onClick={() => deleteMail()}>
+                <S.MenuLogo src="/asset/Delete.svg" />
+                <S.MenuName>삭제</S.MenuName>
+                <div onClick={(e) => e.stopPropagation()}>
+                    {isMobile && isMobileDeleteOpen && <MobileDeleteModal undo={undoDelete} />}
+                </div>
+                </S.Menues>
+                {isMobile && (
+                    <>
+                        <S.MobileMenu src="/asset/MobileMenuDots.svg" onClick={openMobileMenu} />
+                        <MobileMenuModal
+                            isOpen={isMobileMenuOpen}
+                            showRead={showRead}
+                            showNotRead={showNotRead}
+                            command={command}
+                        />
+                    </>
+                )}
+            </S.MenuWrapper>
+        </S.MenuList>
+    )
+}
+
+export default HistoryMenuBar

--- a/src/components/History/History/HistoryMenuBar.js
+++ b/src/components/History/History/HistoryMenuBar.js
@@ -58,7 +58,6 @@ const HistoryMenuBar = ({selectAllMail,checkedList,setCheckedList,showList,setLi
               deleteMailQuery += `notice-id=${mail.id}&`;
             });
             dispatch(deleteHistoryList(deleteMailQuery));
-            console.log(checkedList.map((mail) => {return {mail: mail, index: alertList.indexOf(mail)}}))
             setUndoList(checkedList.map((mail) => {return {mail: mail, index: alertList.indexOf(mail)}}));
             setCheckedList([]);
             setList(alertList.filter((mail) => checkedList.map((element) => element.id).indexOf(mail.id) === -1))
@@ -96,6 +95,19 @@ const HistoryMenuBar = ({selectAllMail,checkedList,setCheckedList,showList,setLi
       const openMobileMenu = () => {
         setMobileMenu(!isMobileMenuOpen);
       };
+      useEffect(() => {
+        if (isMobileDeleteOpen) {
+          setTimeout(() => {
+            setMobileDeleteModal(false);
+            setUndoList([]);
+          }, 4000);
+        } else if (isMobileScrapOpen) {
+          setTimeout(() => {
+            setMobileScrapModal(false);
+            setUndoList([]);
+          }, 4000);
+        }
+      }, [isMobileDeleteOpen, isMobileScrapOpen]);
     return(
         <S.MenuList>
             <S.CheckBox>

--- a/src/components/History/History/HistoryMenuBar.js
+++ b/src/components/History/History/HistoryMenuBar.js
@@ -87,7 +87,6 @@ const HistoryMenuBar = ({selectAllMail,checkedList,setCheckedList,showList,setLi
           undoList.forEach((mail) => {
             redoList.splice(mail.index, 0, mail.mail)
           })
-          console.log(redoList)
           setList(redoList);
           setMobileDeleteModal(false);
         }

--- a/src/components/History/History/HistoryMenuBar.js
+++ b/src/components/History/History/HistoryMenuBar.js
@@ -1,12 +1,12 @@
 import React,{useState,useEffect} from "react";
 import * as S from './History.Style';
 import HistoryCheckBox from './HisoryCheckBox';
-import { moveToScrap, undoHistoryList, deleteHistoryList } from "store/history";
+import { moveToScrap, undoHistoryList, deleteHistoryList, clearHistoryList } from "store/history";
 import { deleteScrapItem } from 'store/scrap';
 import { useDispatch } from "react-redux";
 import { MobileMoveScrapModal, MobileDeleteModal } from "./MobilePopUpModal";
 import MobileMenuModal from './MobileMenuModal';
-const HistoryMenuBar = ({selectAllMail,checkedList,setCheckedList,showList,setList,setOpen,isMobile,setCommand,command,isMobileMenuOpen,setMobileMenu}) => {
+const HistoryMenuBar = ({selectAllMail,checkedList,setCheckedList,showList,setList,setOpen,isMobile,setCommand,command,isMobileMenuOpen,setMobileMenu,setPageNum}) => {
     const dispatch = useDispatch()
     const [undoList, setUndoList] = useState([]);
     const [isMobileDeleteOpen, setMobileDeleteModal] = useState(false);
@@ -28,8 +28,8 @@ const HistoryMenuBar = ({selectAllMail,checkedList,setCheckedList,showList,setLi
     const moveToStorage = () => {
         if (checkedList.length > 0) {
           try {
-            checkedList.forEach((id) => {
-              dispatch(moveToScrap({ crawling_id: id }));
+            checkedList.forEach((mail) => {
+              dispatch(moveToScrap({ crawling_id: mail.crawlingId }));
             });
             setUndoList(checkedList);
             setCheckedList([]);
@@ -47,19 +47,21 @@ const HistoryMenuBar = ({selectAllMail,checkedList,setCheckedList,showList,setLi
         }
       };
     const undoMoveScrap = () => {
-        dispatch(deleteScrapItem(undoList));
+        dispatch(deleteScrapItem(undoList.map((mail) => mail.crawlingId)));
         setUndoList([]);
     };
     const deleteMail = () => {
         if (checkedList.length > 0) {
           try {
             var deleteMailQuery = '';
-            checkedList.forEach((id) => {
-              deleteMailQuery += `notice-id=${id}&`;
+            checkedList.forEach((mail) => {
+              deleteMailQuery += `notice-id=${mail.id}&`;
             });
             dispatch(deleteHistoryList(deleteMailQuery));
-            setUndoList([checkedList]);
+            setUndoList(checkedList);
             setCheckedList([]);
+            setPageNum([1]);
+            dispatch(clearHistoryList())
           } catch (e) {
             console.log(e);
           } finally {
@@ -74,16 +76,18 @@ const HistoryMenuBar = ({selectAllMail,checkedList,setCheckedList,showList,setLi
       const undoDelete = () => {
         var undoMailQuery = '';
         try {
-          undoList.forEach((id) => {
-            undoMailQuery += `notice-id=${id}&`;
+          undoList.forEach((mail) => {
+            undoMailQuery += `notice-id=${mail.id}&`;
           });
           dispatch(undoHistoryList(undoMailQuery));
+          setPageNum([1]);
         } catch (e) {
           console.log(e);
         } finally {
           setUndoList([]);
           setList([]);
           setMobileDeleteModal(false);
+          dispatch(clearHistoryList())
         }
       };
       const openMobileMenu = () => {

--- a/src/components/History/Scrap/MobileScrapAlert.js
+++ b/src/components/History/Scrap/MobileScrapAlert.js
@@ -4,7 +4,7 @@ import HistoryCheckBox from '../History/HisoryCheckBox';
 import * as S from './Scrap.Style';
 import * as M from './MobileScrapAlert.Style';
 import { SITE_LIST } from 'constant';
-import { formatingDate } from "../History/HistoryContent";
+import { formatingDate } from "../History/HistoryAlert";
 import {writeMemo, fixMemo} from 'store/scrap';
 import {useDispatch} from 'react-redux';
 import theme from '../../../theme';

--- a/src/components/History/Scrap/ScrapAlert.js
+++ b/src/components/History/Scrap/ScrapAlert.js
@@ -22,8 +22,6 @@ const makeStringToNewLine = (text) => {
       return fixedText;
     }
   };
-
-// const ScrapAlert = ({mail, isToggleOpen, selectMail, isChecked, memoIdList, fix, write, currentMail, pageState, memoItemList, writeMemoValue, fixMemoValue }) => {
   const ScrapAlert = ({mail, isToggleOpen, selectMail, isChecked, memoIdList, currentMail,  memoItemList, setCurr, setIdList}) => {
     const letter = useRef();
     const memoValue = useRef()
@@ -91,7 +89,6 @@ const makeStringToNewLine = (text) => {
                 </S.AlertProp>
               </S.AlertContent>
               <S.MemoWrapper>
-                {console.log(currentMail)}
                 {memoIdList.includes(mail.userScrapId) ? (
                   <>
                     {mail.userScrapId === currentMail ? null : <S.MemoCircle />}

--- a/src/components/History/Scrap/ScrapAlert.js
+++ b/src/components/History/Scrap/ScrapAlert.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {useState} from "react";
 import * as S from './Scrap.Style'
 import {  Sender } from '../History/History.Style';
 import { SITE_LIST } from 'constant';
@@ -7,6 +7,8 @@ import { useRef } from "react";
 import theme from '../../../theme';
 import HistoryCheckBox from '../History/HisoryCheckBox';
 import { findMemoInAlert } from "./ScrapContent";
+import { useDispatch } from "react-redux";
+import { fixMemo, writeMemo } from "store/scrap";
 const {gray, yellow} = theme.colors;
 const makeStringToNewLine = (text) => {
     if (text) {
@@ -21,8 +23,12 @@ const makeStringToNewLine = (text) => {
     }
   };
 
-const ScrapAlert = ({mail, isToggleOpen, selectMail, isChecked, memoIdList, fix, write, currentMail, pageState, memoItemList, writeMemoValue, fixMemoValue }) => {
+// const ScrapAlert = ({mail, isToggleOpen, selectMail, isChecked, memoIdList, fix, write, currentMail, pageState, memoItemList, writeMemoValue, fixMemoValue }) => {
+  const ScrapAlert = ({mail, isToggleOpen, selectMail, isChecked, memoIdList, currentMail,  memoItemList, setCurr, setIdList}) => {
     const letter = useRef();
+    const memoValue = useRef()
+    const [memoState, setMemoState] = useState('READ')
+    const dispatch = useDispatch();
     const checkByte = (obj) => {
         const len = countLetter(obj.target.value);
         letter.current.innerText = len;
@@ -35,8 +41,36 @@ const ScrapAlert = ({mail, isToggleOpen, selectMail, isChecked, memoIdList, fix,
       const countLetter = (letter) => {
         return letter.length;
       };
+      const customizeMemo = (e, id, state) => {
+        if(memoState === 'READ'){
+          setMemoState(state);
+          e.target.innerText = '완료';
+          setCurr(id);
+        }else{
+          const memoStatement = memoValue.current.value;
+          switch(memoState){
+            case 'FIX':
+              setMemoState('READ');
+              setCurr(null);
+              e.target.innerText = '수정';
+              dispatch(fixMemo({ memo: memoStatement, user_scrap_id: id }));
+              break;
+            case 'WRITE':
+              if (memoStatement !== '') {
+                setMemoState('READ');
+                setIdList([...memoIdList, id]);
+                setCurr(null);
+                e.target.innerText = '수정';
+                dispatch(writeMemo({ memo: memoStatement, user_scrap_id: id }));
+              } else {
+                alert('내용을 적어주세요');
+              }
+              break;
+          }
+        }
+        }
     return(
-        <S.StorageAlert key={mail.id} isToggleOpen={isToggleOpen}>
+        <S.StorageAlert isToggleOpen={isToggleOpen}>
             <HistoryCheckBox
               onClick={(e) => selectMail(e, mail.id)}
               checked={isChecked}
@@ -48,26 +82,27 @@ const ScrapAlert = ({mail, isToggleOpen, selectMail, isChecked, memoIdList, fix,
                 <S.AlertTitle href={mail.url}>{mail.title}</S.AlertTitle>
                 <S.AlertProp>
                   {memoIdList.includes(mail.userScrapId) ? (
-                    <S.MemoOption onClick={(e) => fix(e, mail.userScrapId)}>수정</S.MemoOption>
+                    <S.MemoOption onClick={(e) => customizeMemo(e, mail.userScrapId, 'FIX')}>수정</S.MemoOption>
                   ) : (
-                    <S.MemoOption onClick={(e) => write(e, mail.userScrapId)}>메모</S.MemoOption>
+                    <S.MemoOption onClick={(e) => customizeMemo(e, mail.userScrapId, 'WRITE')}>메모</S.MemoOption>
                   )}
                   <S.DivideLine src="/asset/DivideLine.svg" />
                   <S.ReceiveDate>{formatingDate(mail.created_at)}</S.ReceiveDate>
                 </S.AlertProp>
               </S.AlertContent>
               <S.MemoWrapper>
+                {console.log(currentMail)}
                 {memoIdList.includes(mail.userScrapId) ? (
                   <>
                     {mail.userScrapId === currentMail ? null : <S.MemoCircle />}
-                    {mail.userScrapId === currentMail && (pageState === 'FIX' || pageState === 'WRITE') ? (
+                    {mail.userScrapId === currentMail && (memoState === 'FIX' || memoState === 'WRITE') ? (
                       <S.memoContent>
                         <S.MemoPanel>
                           <S.WriteBlock
                             defaultValue={findMemoInAlert(memoItemList, mail)}
                             onChange={(e) => checkByte(e)}
                             maxLength={100}
-                            ref={fixMemoValue}
+                            ref={memoValue}
                             isToggleOpen={isToggleOpen}
                           />
                           <S.LetterCounter>
@@ -84,9 +119,10 @@ const ScrapAlert = ({mail, isToggleOpen, selectMail, isChecked, memoIdList, fix,
                       <S.MemoBlock>{makeStringToNewLine(findMemoInAlert(memoItemList, mail)[0])}</S.MemoBlock>
                     )}
                   </>
-                ) : mail.userScrapId === currentMail && (pageState === 'FIX' || pageState === 'WRITE') ? (
+                ) :  
+                mail.userScrapId === currentMail && memoState === 'WRITE' ? (
                   <S.memoContent>
-                    <S.WriteBlock onChange={(e) => checkByte(e)} maxLength={100} ref={writeMemoValue} />
+                    <S.WriteBlock onChange={(e) => checkByte(e)} maxLength={100} ref={memoValue} />
                     <S.LetterCounter>
                       <span ref={letter}>0</span>/100
                     </S.LetterCounter>

--- a/src/components/History/Scrap/ScrapAlert.js
+++ b/src/components/History/Scrap/ScrapAlert.js
@@ -22,10 +22,9 @@ const makeStringToNewLine = (text) => {
       return fixedText;
     }
   };
-  const ScrapAlert = ({mail, isToggleOpen, selectMail, isChecked, memoIdList, currentMail,  memoItemList, setCurr, setIdList}) => {
+  const ScrapAlert = ({mail, isToggleOpen, selectMail, isChecked, memoIdList, currentMail,  memoItemList, setCurr, setIdList, memoState, setMemoState}) => {
     const letter = useRef();
     const memoValue = useRef()
-    const [memoState, setMemoState] = useState('READ')
     const dispatch = useDispatch();
     const checkByte = (obj) => {
         const len = countLetter(obj.target.value);
@@ -40,11 +39,16 @@ const makeStringToNewLine = (text) => {
         return letter.length;
       };
       const customizeMemo = (e, id, state) => {
+        
         if(memoState === 'READ'){
           setMemoState(state);
           e.target.innerText = '완료';
           setCurr(id);
         }else{
+          if(currentMail !== id){
+            alert('작성하신 메모를 먼저 저장해주세요')
+            return
+          }
           const memoStatement = memoValue.current.value;
           switch(memoState){
             case 'FIX':
@@ -80,9 +84,9 @@ const makeStringToNewLine = (text) => {
                 <S.AlertTitle href={mail.url}>{mail.title}</S.AlertTitle>
                 <S.AlertProp>
                   {memoIdList.includes(mail.userScrapId) ? (
-                    <S.MemoOption onClick={(e) => customizeMemo(e, mail.userScrapId, 'FIX')}>수정</S.MemoOption>
+                    <S.MemoOption onClick={(e) => customizeMemo(e, mail.userScrapId, 'FIX')}>{currentMail===mail.userScrapId?'완료':'수정'}</S.MemoOption>
                   ) : (
-                    <S.MemoOption onClick={(e) => customizeMemo(e, mail.userScrapId, 'WRITE')}>메모</S.MemoOption>
+                    <S.MemoOption onClick={(e) => customizeMemo(e, mail.userScrapId, 'WRITE')}>{currentMail===mail.userScrapId?'완료':'메모'}</S.MemoOption>
                   )}
                   <S.DivideLine src="/asset/DivideLine.svg" />
                   <S.ReceiveDate>{formatingDate(mail.created_at)}</S.ReceiveDate>

--- a/src/components/History/Scrap/ScrapAlert.js
+++ b/src/components/History/Scrap/ScrapAlert.js
@@ -1,0 +1,101 @@
+import React from "react";
+import * as S from './Scrap.Style'
+import {  Sender } from '../History/History.Style';
+import { SITE_LIST } from 'constant';
+import { formatingDate } from '../History/HistoryAlert';
+import { useRef } from "react";
+import theme from '../../../theme';
+import HistoryCheckBox from '../History/HisoryCheckBox';
+import { findMemoInAlert } from "./ScrapContent";
+const {gray, yellow} = theme.colors;
+const makeStringToNewLine = (text) => {
+    if (text) {
+      const fixedText = text.split('').map((char) => {
+        if (char == '\n') {
+          return <br />;
+        } else {
+          return char;
+        }
+      });
+      return fixedText;
+    }
+  };
+
+const ScrapAlert = ({mail, isToggleOpen, selectMail, isChecked, memoIdList, fix, write, currentMail, pageState, memoItemList, writeMemoValue, fixMemoValue }) => {
+    const letter = useRef();
+    const checkByte = (obj) => {
+        const len = countLetter(obj.target.value);
+        letter.current.innerText = len;
+        if(len >= 100){
+          letter.current.style.color = yellow;
+        }else{
+          letter.current.style.color = gray;
+        }
+      };
+      const countLetter = (letter) => {
+        return letter.length;
+      };
+    return(
+        <S.StorageAlert key={mail.id} isToggleOpen={isToggleOpen}>
+            <HistoryCheckBox
+              onClick={(e) => selectMail(e, mail.id)}
+              checked={isChecked}
+              readOnly
+            />
+            <Sender>{SITE_LIST[SITE_LIST.findIndex((site) => site.id === mail.site)].title}</Sender>
+            <S.MemoAlertWrapper isToggleOpen={isToggleOpen}>
+              <S.AlertContent isToggleOpen={isToggleOpen}>
+                <S.AlertTitle href={mail.url}>{mail.title}</S.AlertTitle>
+                <S.AlertProp>
+                  {memoIdList.includes(mail.userScrapId) ? (
+                    <S.MemoOption onClick={(e) => fix(e, mail.userScrapId)}>수정</S.MemoOption>
+                  ) : (
+                    <S.MemoOption onClick={(e) => write(e, mail.userScrapId)}>메모</S.MemoOption>
+                  )}
+                  <S.DivideLine src="/asset/DivideLine.svg" />
+                  <S.ReceiveDate>{formatingDate(mail.created_at)}</S.ReceiveDate>
+                </S.AlertProp>
+              </S.AlertContent>
+              <S.MemoWrapper>
+                {memoIdList.includes(mail.userScrapId) ? (
+                  <>
+                    {mail.userScrapId === currentMail ? null : <S.MemoCircle />}
+                    {mail.userScrapId === currentMail && (pageState === 'FIX' || pageState === 'WRITE') ? (
+                      <S.memoContent>
+                        <S.MemoPanel>
+                          <S.WriteBlock
+                            defaultValue={findMemoInAlert(memoItemList, mail)}
+                            onChange={(e) => checkByte(e)}
+                            maxLength={100}
+                            ref={fixMemoValue}
+                            isToggleOpen={isToggleOpen}
+                          />
+                          <S.LetterCounter>
+                            <S.LettterLength
+                              ref={letter}
+                            >
+                              {findMemoInAlert(memoItemList, mail)[0].length}
+                            </S.LettterLength>
+                            /100
+                          </S.LetterCounter>
+                        </S.MemoPanel>
+                      </S.memoContent>
+                    ) : (
+                      <S.MemoBlock>{makeStringToNewLine(findMemoInAlert(memoItemList, mail)[0])}</S.MemoBlock>
+                    )}
+                  </>
+                ) : mail.userScrapId === currentMail && (pageState === 'FIX' || pageState === 'WRITE') ? (
+                  <S.memoContent>
+                    <S.WriteBlock onChange={(e) => checkByte(e)} maxLength={100} ref={writeMemoValue} />
+                    <S.LetterCounter>
+                      <span ref={letter}>0</span>/100
+                    </S.LetterCounter>
+                  </S.memoContent>
+                ) : null}
+              </S.MemoWrapper>
+            </S.MemoAlertWrapper>
+          </S.StorageAlert>
+    )
+}
+
+export default ScrapAlert;

--- a/src/components/History/Scrap/ScrapContent.js
+++ b/src/components/History/Scrap/ScrapContent.js
@@ -32,6 +32,7 @@ const ScrapContent = ({isToggleOpen}) => {
   const [scrapItemList, setScrap] = useState([]);
   const [currentMail, setCurr] = useState(null);
   const [checkedList, setCheckedList] = useState([]);
+  const [memoState, setMemoState] = useState('READ')
   const memoValue = useRef();
   const isMobile = useMediaQuery({ query: `(max-width:${theme.deviceSizes.tabletL}` });
   useEffect(() => {
@@ -117,6 +118,8 @@ const ScrapContent = ({isToggleOpen}) => {
               setCurr={setCurr}
               key={mail.id}
               setIdList={setIdList}
+              memoState={memoState}
+              setMemoState={setMemoState}
             />
           ))}
         </S.KeyWordAlertList>

--- a/src/components/History/Scrap/ScrapContent.js
+++ b/src/components/History/Scrap/ScrapContent.js
@@ -1,14 +1,15 @@
-import React, { useState, useEffect, useRef, useLayoutEffect, useMemo } from 'react';
+import React, { useState, useEffect, useRef, useLayoutEffect } from 'react';
 import * as S from './Scrap.Style';
 import {  Sender } from '../History/History.Style';
 import { useDispatch, useSelector } from 'react-redux';
 import HistoryCheckBox from '../History/HisoryCheckBox';
-import { getMemo, getScrapList, deleteScrapItem, fixMemo, writeMemo } from 'store/scrap';
+import { getMemo, getScrapList, fixMemo, writeMemo } from 'store/scrap';
 import { SITE_LIST } from 'constant';
 import { formatingDate } from '../History/HistoryAlert';
 import theme from '../../../theme';
 import { useMediaQuery } from 'react-responsive';
 import MobileScrapAlert from './MobileScrapAlert';
+import ScrapMenuBar from './ScrapMenuBar';
 
 
 const memoState = ['READ', 'WRITE', 'FIX'];
@@ -121,14 +122,14 @@ const ScrapContent = ({isToggleOpen}) => {
       setCheckedList(checkedList.filter((mailId) => mailId !== id));
     }
   };
-  const deleteAlert = () => {
-    if (checkedList.length > 0) {
-      dispatch(deleteScrapItem(checkedList));
-      setCheckedList([]);
-    } else {
-      alert('삭제할 메일을 선택해 주세요');
-    }
-  };
+  // const deleteAlert = () => {
+  //   if (checkedList.length > 0) {
+  //     dispatch(deleteScrapItem(checkedList));
+  //     setCheckedList([]);
+  //   } else {
+  //     alert('삭제할 메일을 선택해 주세요');
+  //   }
+  // };
   const checkByte = (obj) => {
     const len = countLetter(obj.target.value);
     letter.current.innerText = len;
@@ -161,20 +162,13 @@ const ScrapContent = ({isToggleOpen}) => {
     <>
     <S.Wrapper>
       <S.Content>
-      <S.MenuList isToggleOpen={isToggleOpen}>
-        <S.CheckBox>
-          <HistoryCheckBox
-            onClick={(e) => selectAll(e)}
-            checked={checkedList.length <= 0 || checkedList.length !== scrapItemList.length ? false : true}
-            readOnly
-          />
-           <S.SelectAll>전체선택</S.SelectAll>
-        </S.CheckBox>
-        <S.Menu onClick={deleteAlert}>
-          <S.MenuLogo src="/asset/Delete.svg" />
-          <S.MenuName>삭제</S.MenuName>
-        </S.Menu>
-      </S.MenuList>
+      <ScrapMenuBar 
+        isChecked={checkedList.length <= 0 || checkedList.length !== scrapItemList.length ? false : true} 
+        selectAll={selectAll}
+        checkedList={checkedList}
+        setCheckedList={setCheckedList}
+        isToggleOpen={isToggleOpen}
+      />
       <S.KeyWordAlertList scrollOption={scrapItemList?.length >= 12 ? true : false}>
         {scrapItemList?.map((mail) => (
           isMobile? <MobileScrapAlert

--- a/src/components/History/Scrap/ScrapContent.js
+++ b/src/components/History/Scrap/ScrapContent.js
@@ -5,7 +5,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import HistoryCheckBox from '../History/HisoryCheckBox';
 import { getMemo, getScrapList, deleteScrapItem, fixMemo, writeMemo } from 'store/scrap';
 import { SITE_LIST } from 'constant';
-import { formatingDate } from '../History/HistoryContent';
+import { formatingDate } from '../History/HistoryAlert';
 import theme from '../../../theme';
 import { useMediaQuery } from 'react-responsive';
 import MobileScrapAlert from './MobileScrapAlert';

--- a/src/components/History/Scrap/ScrapContent.js
+++ b/src/components/History/Scrap/ScrapContent.js
@@ -8,9 +8,6 @@ import MobileScrapAlert from './MobileScrapAlert';
 import ScrapMenuBar from './ScrapMenuBar';
 import ScrapAlert from './ScrapAlert';
 
-
-const memoState = ['READ', 'WRITE', 'FIX'];
-
 const stringToDate = (date) => {
   var yyyyMMdd = String(date);
   var sYear = yyyyMMdd.substring(0, 4);
@@ -33,11 +30,9 @@ const ScrapContent = ({isToggleOpen}) => {
   const [memoItemList, setMemo] = useState([]);
   const [memoIdList, setIdList] = useState([]);
   const [scrapItemList, setScrap] = useState([]);
-  const [pageState, setState] = useState('READ');
   const [currentMail, setCurr] = useState(null);
   const [checkedList, setCheckedList] = useState([]);
-  const fixMemoValue = useRef(null);
-  const writeMemoValue = useRef();
+  const memoValue = useRef();
   const isMobile = useMediaQuery({ query: `(max-width:${theme.deviceSizes.tabletL}` });
   useEffect(() => {
     if (userInfo.isLoggedIn) {
@@ -54,39 +49,6 @@ const ScrapContent = ({isToggleOpen}) => {
       );
     }
   }, [memoList]);
-  //상태에 따라 메모/수정/완료 표시
-
-  const write = (e, id) => {
-    if (pageState === 'READ') {
-      e.target.innerText = '완료';
-      setState('WRITE');
-      setCurr(id);
-    } else if (pageState === 'WRITE') {
-      const memoStatement = writeMemoValue.current.value;
-      if (memoStatement !== '') {
-        setState('READ');
-        setIdList([...memoIdList, id]);
-        setCurr(null);
-        e.target.innerText = '수정';
-        dispatch(writeMemo({ memo: memoStatement, user_scrap_id: id }));
-      } else {
-        alert('내용을 적어주세요');
-      }
-    }
-  };
-  const fix = (e, id) => {
-    if (pageState === 'READ') {
-      setState('FIX');
-      e.target.innerText = '완료';
-      setCurr(id);
-    } else if (pageState === 'FIX') {
-      setState('READ');
-      setCurr(null);
-      e.target.innerText = '수정';
-      const memoStatement = fixMemoValue.current.value;
-      dispatch(fixMemo({ memo: memoStatement, user_scrap_id: id }));
-    }
-  };
   const selectAll = (e) => {
     if (e.target.checked) {
       setCheckedList(
@@ -124,42 +86,40 @@ const ScrapContent = ({isToggleOpen}) => {
     <>
     <S.Wrapper>
       <S.Content>
-      <ScrapMenuBar 
-        isChecked={checkedList.length <= 0 || checkedList.length !== scrapItemList.length ? false : true} 
-        selectAll={selectAll}
-        checkedList={checkedList}
-        setCheckedList={setCheckedList}
-        isToggleOpen={isToggleOpen}
-      />
-      <S.KeyWordAlertList scrollOption={scrapItemList?.length >= 12 ? true : false}>
-        {scrapItemList?.map((mail) => (
-          isMobile? <MobileScrapAlert
-                      mail={mail}
-                      selectMail={selectMail}
-                      list={checkedList}
-                      memo={findMemoInAlert(memoItemList, mail)}
-                      writeId={currentMail}
-                      setCurr={setCurr}
-                      key={mail.id}
-                      />
-          :
-          <ScrapAlert
-            mail={mail}
-            isToggleOpen={isToggleOpen}
-            selectMail={selectMail}
-            isChecked={checkedList.includes(mail.id) ? true : false}
-            memoIdList={memoIdList}
-            fix={fix}
-            write={write}
-            currentMail={currentMail}
-            pageState={pageState}
-            memoItemList={memoItemList}
-            writeMemoValue={writeMemoValue}
-            fixMemoValue={fixMemoValue}
-            key={mail.id}
-          />
-        ))}
-      </S.KeyWordAlertList>
+        <ScrapMenuBar 
+          isChecked={checkedList.length <= 0 || checkedList.length !== scrapItemList.length ? false : true} 
+          selectAll={selectAll}
+          checkedList={checkedList}
+          setCheckedList={setCheckedList}
+          isToggleOpen={isToggleOpen}
+        />
+        <S.KeyWordAlertList scrollOption={scrapItemList?.length >= 12 ? true : false}>
+          {scrapItemList?.map((mail) => (
+            isMobile? <MobileScrapAlert
+                        mail={mail}
+                        selectMail={selectMail}
+                        list={checkedList}
+                        memo={findMemoInAlert(memoItemList, mail)}
+                        writeId={currentMail}
+                        setCurr={setCurr}
+                        key={mail.id}
+                        />
+            :
+            <ScrapAlert
+              mail={mail}
+              isToggleOpen={isToggleOpen}
+              selectMail={selectMail}
+              isChecked={checkedList.includes(mail.id) ? true : false}
+              memoIdList={memoIdList}
+              currentMail={currentMail}
+              memoItemList={memoItemList}
+              memoValue={memoValue}
+              setCurr={setCurr}
+              key={mail.id}
+              setIdList={setIdList}
+            />
+          ))}
+        </S.KeyWordAlertList>
       </S.Content>
       
     </S.Wrapper>

--- a/src/components/History/Scrap/ScrapMenuBar.js
+++ b/src/components/History/Scrap/ScrapMenuBar.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import { deleteScrapItem } from 'store/scrap';
+import { useDispatch } from 'react-redux';
+import * as S from './Scrap.Style';
+import HistoryCheckBox from '../History/HisoryCheckBox';
+const ScrapMenuBar = ({selectAll, isChecked, checkedList, setCheckedList, isToggleOpen}) => {
+    const dispatch = useDispatch();
+    const deleteAlert = () => {
+        if (checkedList.length > 0) {
+          dispatch(deleteScrapItem(checkedList));
+          setCheckedList([]);
+        } else {
+          alert('삭제할 메일을 선택해 주세요');
+        }
+      };
+    return (
+        <S.MenuList isToggleOpen={isToggleOpen}>
+        <S.CheckBox>
+          <HistoryCheckBox
+            onClick={(e) => selectAll(e)}
+            checked={isChecked}
+            readOnly
+          />
+           <S.SelectAll>전체선택</S.SelectAll>
+        </S.CheckBox>
+        <S.Menu onClick={deleteAlert}>
+          <S.MenuLogo src="/asset/Delete.svg" />
+          <S.MenuName>삭제</S.MenuName>
+        </S.Menu>
+      </S.MenuList>
+    )
+}
+
+export default ScrapMenuBar;

--- a/src/store/history.js
+++ b/src/store/history.js
@@ -60,7 +60,8 @@ const history = handleActions(
   {
     [GET_HISTORY_LIST_SUCCESS]: (state, { payload: history }) => ({
       ...state,
-      historyList: state.historyList.concat(history.body.length===0?null:history.body),
+      // historyList: state.historyList.concat(history.body.length===0?null:history.body),
+      historyList: history.body.length===0?null:history.body,
       getHistoryListResponse: true,
       deleteHistoryResponse: false,
       readHistoryItemResponse: false,
@@ -77,7 +78,6 @@ const history = handleActions(
 
     [DELETE_HISTORY_LIST_SUCCESS]: (state) => ({
       ...state,
-      historyList: [],
       deleteHistoryResponse: true,
     }),
     [DELETE_HISTORY_LIST_FAILURE]: (state) => ({
@@ -110,7 +110,6 @@ const history = handleActions(
 
     [UNDO_HISTORY_LIST_SUCCESS]: (state) => ({
       ...state,
-      historyList: [],
       undoHistoryListResponse: true,
     }),
     [UNDO_HISTORY_LIST_FAILURE]: (state) => ({

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -40,6 +40,7 @@ import history, {
   readHistoryItemSaga,
   moveToScrapItemSaga,
   undoHistoryListSaga,
+  clearHistoryList,
 } from './history';
 import scrap, { getScrapListSaga, getMemoSaga, deleteScrapItemSaga, fixMemoSaga, writeMemoSaga } from './scrap';
 
@@ -88,6 +89,7 @@ export function* rootSaga() {
     readHistoryItemSaga(),
     undoHistoryListSaga(),
     moveToScrapItemSaga(),
+    clearHistoryList(),
     getHistoryListSaga(),
     getScrapListSaga(),
     getMemoSaga(),


### PR DESCRIPTION
## 개요 <!-- 작업 내역 한줄 요약, 스크린샷 등 -->
히스토리 페이지와 보관함 페이지 HistoryContent.js와 StorageContent.js에 있는 요소들 컴포넌트 단위로 분리했습니다. 
## 이슈 번호

- closes [#71 ]

## 변경사항 <!-- 필수, 상세히 작성(목록화 등)하면 간결한 코드리뷰가 가능해집니다 -->
히스토리 페이지와 보관함 페이지 HistoryContent.js와 StorageContent.js에 있는 요소들 컴포넌트 단위로 분리했습니다. 
히스토리 페이지 테스트하면서 버그 수정했습니다.
보관함 페이지 테스트하면서 버그 수정했습니다. 

## 특이사항 <!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->
컴포넌트로 분리하면서 props가 꽤 많이 생기게 되었는데 이를 좀 줄일 방법 없을까요??