### PR TITLE
fix : 폰트 반복렌더링(깜빡임) 현상 수정

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -1,0 +1,38 @@
+@font-face {
+  font-family: 'NotoSansCJKKR';
+  font-weight: normal;
+  font-style: normal;
+  src: url(asset/fonts/NotoSansCJKkr/NotoSansCJKkr-Regular.otf) format('woff');
+}
+@font-face {
+  font-family: 'NotoSansCJKKR';
+  font-weight: 500;
+  font-style: normal;
+  src: url(asset/fonts/NotoSansCJKkr/NotoSansCJKkr-Medium.otf) format('opentype');
+}
+@font-face {
+  font-family: 'NotoSansCJKKR';
+  font-weight: bold;
+  font-style: normal;
+  src: url(asset/fonts/NotoSansCJKkr/NotoSansCJKkr-Bold.otf) format('opentype');
+}
+
+@font-face {
+  font-family: 'NotoSansKR';
+  font-weight: normal; 
+  font-style: normal;
+  src: url(asset/fonts/NotoSansKR/NotoSansKR-Regular.woff) format('woff');
+}
+@font-face {
+    font-family: 'NotoSansKR';
+    font-weight: 500;
+    font-style: normal;
+    src: url(asset/fonts/NotoSansKR/NotoSansKR-Medium.woff) format('woff');
+}
+
+@font-face {
+  font-family: 'NanumSquareRound';
+  font-weight: bold;
+  font-style: normal;
+  src: url(asset/fonts/other/NanumSquareRoundOTFB.otf) format('opentype');
+}

--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,7 @@
     <meta name="description" content="한기대 키워드 알림 서비스" />
     <meta name="author" content="BCSD Lab" />
     <link rel="icon" type="image/png" href="%PUBLIC_URL%/favicon.ico" />
+    <link rel="stylesheet" href="%PUBLIC_URL%/index.css" />
     <meta property="og:image" content="/icons/koala_showcase_img.png" />
     <meta property="og:image:width" content="1200" />
 

--- a/src/GlobalStyle.js
+++ b/src/GlobalStyle.js
@@ -1,45 +1,6 @@
 import { createGlobalStyle } from 'styled-components';
 
 export const GlobalStyle = createGlobalStyle`
-  @font-face {
-    font-family: 'NotoSansCJKKR';
-    font-weight: normal;
-    font-style: normal;
-    src: url(/asset/fonts/NotoSansCJKkr/NotoSansCJKkr-Regular.otf) format('woff');
-  }
-  @font-face {
-    font-family: 'NotoSansCJKKR';
-    font-weight: 500;
-    font-style: normal;
-    src: url(/asset/fonts/NotoSansCJKkr/NotoSansCJKkr-Medium.otf) format('opentype');
-  }
-  @font-face {
-    font-family: 'NotoSansCJKKR';
-    font-weight: bold;
-    font-style: normal;
-    src: url(/asset/fonts/NotoSansCJKkr/NotoSansCJKkr-Bold.otf) format('opentype');
-  }
-  
-  @font-face {
-    font-family: 'NotoSansKR';
-    font-weight: normal; 
-    font-style: normal;
-    src: url(/asset/fonts/NotoSansKR/NotoSansKR-Regular.woff) format('woff');
-  }
-  @font-face {
-      font-family: 'NotoSansKR';
-      font-weight: 500;
-      font-style: normal;
-      src: url(/asset/fonts/NotoSansKR/NotoSansKR-Medium.woff) format('woff');
-  }
-
-  @font-face {
-    font-family: 'NanumSquareRound';
-    font-weight: bold;
-    font-style: normal;
-    src: url(/asset/fonts/other/NanumSquareRoundOTFB.otf) format('opentype');
-}
-
 
   html, body, #root{
     font-family: 'NotoSansCJKKR', 'Noto Sans KR', 'Noto Sans', sans-serif;


### PR DESCRIPTION
## 개요 <!-- 작업 내역 한줄 요약, 스크린샷 등 -->

각 컴포넌트 렌더링 시 전체 APP의 글꼴이 다시 렌더링되는 현상

## 관련 이슈

 - https://github.com/styled-components/styled-components/issues/2900

## 변경사항 <!-- 필수, 상세히 작성(목록화 등)하면 간결한 코드리뷰가 가능해집니다 -->

 - createGlobalStyle의 font-face 제거
 - public directory를 사용하고 있어 해당 위치의 폰트를 렌더링하는 css파일 추가

## 특이사항 <!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->

깜빡임 현상 이전과 비교하며 봐주세요